### PR TITLE
fix: parameters for sending eth

### DIFF
--- a/typescript/packages/core/src/utils.ts
+++ b/typescript/packages/core/src/utils.ts
@@ -1,55 +1,47 @@
-import type { ZodTypeAny } from "zod";
 import { z } from "zod";
+import type { ZodTypeAny } from "zod";
+
+function getTypeString(schema: z.ZodTypeAny): string {
+    const typeName = schema._def?.typeName;
+    
+    switch (typeName) {
+        case "ZodOptional":
+            return getTypeString((schema as z.ZodOptional<any>).unwrap());
+        case "ZodString":
+            return "string";
+        case "ZodNumber":
+            return "number";
+        case "ZodBoolean":
+            return "boolean";
+        case "ZodArray":
+            return "array";
+        case "ZodObject":
+            return "object";
+        default:
+            return "unknown";
+    }
+}
 
 export function addParametersToDescription(description: string, schema: z.ZodTypeAny): string {
     let paramLines: string[] = [];
 
-    if (schema instanceof z.ZodObject) {
-        const shape = schema.shape;
-        paramLines = Object.entries<ZodTypeAny>(shape).map(([key, value]) => {
-            const isOptional = value.isOptional();
-            const paramDescription = value.description || "";
-            const typeStr = getTypeString(value);
-
-            return `- ${key}${isOptional ? " (optional)" : ""} (${typeStr}): ${paramDescription}`;
-        });
-    } else {
-        const isOptional = schema.isOptional();
-        const paramDescription = schema.description || "";
-        const typeStr = getTypeString(schema);
-
-        paramLines.push(`- ${isOptional ? "(optional) " : ""}(${typeStr}): ${paramDescription}`);
+    if (schema._def?.typeName === "ZodObject") {
+        const shape = schema._def.shape();
+        if (shape) {
+            paramLines = Object.entries<ZodTypeAny>(shape).map(([key, value]) => {
+                const isOptional = value.isOptional();
+                const paramDescription = value.description || "";
+                const typeStr = getTypeString(value);
+                return `- ${key}${isOptional ? " (optional)" : ""} (${typeStr}): ${paramDescription}`;
+            });
+        }
     }
 
     return `${description}\n${paramLines.join("\n")}`;
 }
 
-function getTypeString(schema: z.ZodTypeAny): string {
-    if (schema instanceof z.ZodOptional) {
-        // Recursively get the type of the inner schema
-        return getTypeString(schema.unwrap());
-    }
-    if (schema instanceof z.ZodString) {
-        return "string";
-    }
-    if (schema instanceof z.ZodNumber) {
-        return "number";
-    }
-    if (schema instanceof z.ZodBoolean) {
-        return "boolean";
-    }
-    if (schema instanceof z.ZodArray) {
-        return "array";
-    }
-    if (schema instanceof z.ZodObject) {
-        return "object";
-    }
-    return "unknown";
-}
-
-export function replaceToolPlaceholder(template: string, wordForTool = "tool"): string {
-    const placeholderRegex = /\{\{\s*tool\s*\}\}/g;
-    return template.replace(placeholderRegex, wordForTool);
+export function replaceToolPlaceholder(text: string, toolName: string): string {
+    return text.replace(/\{\{tool\}\}/g, toolName);
 }
 
 export function parametersToJsonExample(parameters: z.ZodTypeAny): string {
@@ -57,44 +49,38 @@ export function parametersToJsonExample(parameters: z.ZodTypeAny): string {
     return JSON.stringify(exampleObject, null, 2);
 
     function generateExample(schema: z.ZodTypeAny): unknown {
-        if (schema instanceof z.ZodString) {
-            return "string";
-        }
-        if (schema instanceof z.ZodNumber) {
-            return 0;
-        }
-        if (schema instanceof z.ZodBoolean) {
-            return false;
-        }
-        if (schema instanceof z.ZodArray) {
-            const elementSchema = schema._def.type;
-            return [generateExample(elementSchema)];
-        }
-        if (schema instanceof z.ZodObject) {
-            const shape = schema._def.shape();
-            const obj: Record<string, unknown> = {};
-            for (const [key, valueSchema] of Object.entries(shape)) {
-                obj[key] = generateExample(valueSchema as ZodTypeAny);
+        const typeName = schema._def?.typeName;
+        
+        switch (typeName) {
+            case "ZodString":
+                return "string";
+            case "ZodNumber":
+                return 0;
+            case "ZodBoolean":
+                return false;
+            case "ZodArray":
+                return [generateExample(schema._def.type)];
+            case "ZodObject": {
+                const shape = schema._def.shape();
+                const obj: Record<string, unknown> = {};
+                for (const [key, valueSchema] of Object.entries(shape)) {
+                    obj[key] = generateExample(valueSchema as ZodTypeAny);
+                }
+                return obj;
             }
-            return obj;
+            case "ZodOptional":
+            case "ZodNullable":
+                return generateExample((schema as z.ZodOptional<any>).unwrap());
+            case "ZodUnion":
+                return generateExample(schema._def.options[0]); // Use first option
+            case "ZodLiteral":
+                return schema._def.value;
+            case "ZodEnum":
+                return schema._def.values[0]; // Use first enum value
+            case "ZodDefault":
+                return generateExample(schema._def.innerType);
+            default:
+                return null;
         }
-        if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable) {
-            const innerSchema = schema.unwrap();
-            return generateExample(innerSchema);
-        }
-        if (schema instanceof z.ZodUnion) {
-            const options = schema._def.options;
-            return generateExample(options[0]); // Use the first option as an example
-        }
-        if (schema instanceof z.ZodLiteral) {
-            return schema._def.value;
-        }
-        if (schema instanceof z.ZodEnum) {
-            return schema._def.values[0]; // Use the first enum value as an example
-        }
-        if (schema instanceof z.ZodDefault) {
-            return generateExample(schema._def.innerType);
-        }
-        return null; // Default value if type is unrecognized
     }
 }


### PR DESCRIPTION
# Background

## What does this PR do?
Previously, the parameters for send_eth were not correctly parsed, due to it being a self implemented method. It was failing the instanceOf check, so we moved to schema._def?.typeName check instead.

## What kind of change is this?
Bug fix

# Documentation changes needed?
My changes do not require a change to the project documentation.


# Testing

## Detailed testing steps
Locally

## For plugins
- [] I have tested this change locally with key pair wallets
- [X] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)

## Discord username
