### PR TITLE
Crossmint Balance API

### DIFF
--- a/typescript/examples/vercel-ai/crossmint-smart-wallets/index.ts
+++ b/typescript/examples/vercel-ai/crossmint-smart-wallets/index.ts
@@ -4,7 +4,6 @@ import { generateText } from "ai";
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
 import { sendETH } from "@goat-sdk/core";
 import { crossmint } from "@goat-sdk/crossmint";
-import { USDC, erc20 } from "@goat-sdk/plugin-erc20";
 
 require("dotenv").config();
 
@@ -17,7 +16,7 @@ if (!apiKey || !walletSignerSecretKey || !alchemyApiKey || !smartWalletAddress) 
     throw new Error("Missing environment variables");
 }
 
-const { smartwallet, faucet } = crossmint(apiKey);
+const { smartwallet, faucet, balance } = crossmint(apiKey);
 
 (async () => {
     const tools = await getOnChainTools({
@@ -29,14 +28,14 @@ const { smartwallet, faucet } = crossmint(apiKey);
             chain: "base-sepolia",
             provider: alchemyApiKey,
         }),
-        plugins: [sendETH(), erc20({ tokens: [USDC] }), faucet()],
+        plugins: [sendETH(), balance(), faucet()],
     });
 
     const result1 = await generateText({
         model: openai("gpt-4o-mini"),
         tools: tools,
         maxSteps: 5,
-        prompt: "Top up my wallet with USDC",
+        prompt: "Fund my wallet with 5 USDC",
     });
 
     console.log(result1.text);
@@ -45,7 +44,7 @@ const { smartwallet, faucet } = crossmint(apiKey);
         model: openai("gpt-4o-mini"),
         tools: tools,
         maxSteps: 5,
-        prompt: "Get my balance in USDC",
+        prompt: "Fetch my USDC balance on base-sepolia",
     });
 
     console.log(result2.text);

--- a/typescript/examples/vercel-ai/crossmint-solana-custodial-wallets/index.ts
+++ b/typescript/examples/vercel-ai/crossmint-solana-custodial-wallets/index.ts
@@ -14,7 +14,7 @@ if (!apiKey || !email) {
     throw new Error("Missing environment variables");
 }
 
-const { custodial } = crossmint(apiKey);
+const { custodial, balance } = crossmint(apiKey);
 
 (async () => {
     const tools = await getOnChainTools({
@@ -23,13 +23,14 @@ const { custodial } = crossmint(apiKey);
             email: email,
             connection: new Connection("https://api.devnet.solana.com", "confirmed"),
         }),
+        plugins: [balance()],
     });
 
     const result = await generateText({
         model: openai("gpt-4o-mini"),
         tools: tools,
         maxSteps: 5,
-        prompt: "Get my balance in SOL",
+        prompt: "Get my balance in BONK",
     });
 
     console.log(result.text);

--- a/typescript/packages/wallets/crossmint/src/api.ts
+++ b/typescript/packages/wallets/crossmint/src/api.ts
@@ -180,6 +180,36 @@ interface ApproveSignatureResponse {
 }
 
 ////////////////////////////////////////////////////////////////////
+// Get Wallet Balance
+////////////////////////////////////////////////////////////////////
+interface WalletBalance {
+    currency: string;
+    decimals: number;
+    balances: {
+        [chain: string]: string;
+        total: string;
+    };
+}
+
+export const SUPPORTED_CURRENCIES = [
+    "eth", "matic", "pol", "sei", "chz", "avax", "xai", "fuel", 
+    "vic", "usdc", "usdce", "busd", "usdxm", "weth", "degen", 
+    "brett", "toshi", "eurc", "superverse", "bonk", "wif", 
+    "mother", "sol", "ada", "bnb", "sui", "apt", "sfuel"
+] as const;
+
+export type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
+
+interface GetWalletBalanceParams {
+    currencies: SupportedCurrency[];
+    chains?: string[];
+}
+
+interface GetWalletBalanceResponse {
+    balances: WalletBalance[];
+}
+
+////////////////////////////////////////////////////////////////////
 // API
 ////////////////////////////////////////////////////////////////////
 
@@ -190,7 +220,8 @@ type APIResponse =
     | SubmitApprovalResponse
     | SignMessageResponse
     | SignTypedDataResponse
-    | ApproveSignatureResponse;
+    | ApproveSignatureResponse
+    | GetWalletBalanceResponse;
 
 export function createCrossmintAPI(crossmintClient: CrossmintApiClient) {
     const baseUrl = `${crossmintClient.baseUrl}/api/v1-alpha2`;
@@ -409,6 +440,21 @@ export function createCrossmintAPI(crossmintClient: CrossmintApiClient) {
             return (await request(endpoint, {
                 method: "GET",
             })) as TransactionStatusResponse;
+        },
+        getWalletBalance: async (
+            locator: string, 
+            params: GetWalletBalanceParams
+        ): Promise<GetWalletBalanceResponse> => {
+            const queryParams = new URLSearchParams();
+            queryParams.append('currencies', params.currencies.join(','));
+            if (params.chains) {
+                queryParams.append('chains', params.chains.join(','));
+            }
+            
+            const endpoint = `/wallets/${encodeURIComponent(locator)}/balances?${queryParams}`;
+            return (await request(endpoint, {
+                method: "GET",
+            })) as GetWalletBalanceResponse;
         },
     };
 }

--- a/typescript/packages/wallets/crossmint/src/api.ts
+++ b/typescript/packages/wallets/crossmint/src/api.ts
@@ -191,21 +191,31 @@ interface WalletBalance {
     };
 }
 
-export const SUPPORTED_CURRENCIES = [
-    "eth", "matic", "pol", "sei", "chz", "avax", "xai", "fuel", 
-    "vic", "usdc", "usdce", "busd", "usdxm", "weth", "degen", 
-    "brett", "toshi", "eurc", "superverse", "bonk", "wif", 
-    "mother", "sol", "ada", "bnb", "sui", "apt", "sfuel"
+export const SOLANA_SUPPORTED_CURRENCIES = [
+    "eurc", "bonk", "wif", "mother", "sol", "usdc"
 ] as const;
 
-export type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
+export const EVM_SUPPORTED_CURRENCIES = [
+    "eth", "matic", "pol", "sei", "chz", "avax", "xai", "fuel", 
+    "vic", "usdc", "usdce", "busd", "usdxm", "weth", "degen", 
+    "brett", "toshi", "eurc", "bnb", "sui", "sfuel"
+] as const;
+
+export const SUPPORTED_CURRENCIES = [
+    ...EVM_SUPPORTED_CURRENCIES,
+    ...SOLANA_SUPPORTED_CURRENCIES
+] as const;
+
+export type SupportedEVMCurrency = typeof EVM_SUPPORTED_CURRENCIES[number];
+export type SupportedSolanaCurrency = typeof SOLANA_SUPPORTED_CURRENCIES[number];
+export type SupportedCurrency = SupportedEVMCurrency | SupportedSolanaCurrency;
 
 interface GetWalletBalanceParams {
     currencies: SupportedCurrency[];
     chains?: string[];
 }
 
-interface GetWalletBalanceResponse {
+export interface GetWalletBalanceResponse {
     balances: WalletBalance[];
 }
 

--- a/typescript/packages/wallets/crossmint/src/balance.ts
+++ b/typescript/packages/wallets/crossmint/src/balance.ts
@@ -23,7 +23,7 @@ export function balanceFactory(client: CrossmintApiClient) {
                 return [
                     {
                         name: "get_token_balances",
-                        description: "This {{tool}} gets your wallet token balances",
+                        description: "This {{tool}} gets token balances across multiple chains and tokens for any wallet address",
                         parameters: getBalanceParametersSchema,
                         method: async (
                             walletClient: CrossmintEVMSmartWalletClient | CrossmintSolanaCustodialWalletClient,

--- a/typescript/packages/wallets/crossmint/src/balance.ts
+++ b/typescript/packages/wallets/crossmint/src/balance.ts
@@ -1,0 +1,49 @@
+import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
+import type { Chain, EVMWalletClient, Plugin } from "@goat-sdk/core";
+import { z } from "zod";
+import { SUPPORTED_CURRENCIES, SupportedEVMCurrency, SupportedSolanaCurrency } from "./api";
+import { CrossmintEVMSmartWalletClient } from "./smart-wallet";
+import { CrossmintSolanaCustodialWalletClient } from "./custodial";
+
+export const getBalanceParametersSchema = z.object({
+    wallet: z.string().optional().describe("The address to check the balance of"),
+    currencies: z.array(z.enum(SUPPORTED_CURRENCIES)).optional()
+        .describe("The currencies to check balances for"),
+    chains: z.array(z.string()).optional()
+        .describe("The chains to check balances for"),
+});
+
+export function balanceFactory(client: CrossmintApiClient) {
+    return function balance(): Plugin<CrossmintEVMSmartWalletClient | CrossmintSolanaCustodialWalletClient> {
+        return {
+            name: "Crossmint Balance",
+            supportsChain: (chain: Chain) => true,
+            supportsSmartWallets: () => true,
+            getTools: async () => {
+                return [
+                    {
+                        name: "get_token_balances",
+                        description: "This {{tool}} gets your wallet token balances",
+                        parameters: getBalanceParametersSchema,
+                        method: async (
+                            walletClient: CrossmintEVMSmartWalletClient | CrossmintSolanaCustodialWalletClient,
+                            parameters: z.infer<typeof getBalanceParametersSchema>,
+                        ) => {
+                            const wallet = parameters.wallet ?? walletClient.getAddress();
+                            const currencies = parameters.currencies ?? SUPPORTED_CURRENCIES;
+                            
+                            if (walletClient.getChain().type === "evm") {
+                                const chains = parameters.chains;
+                                if (chains === undefined) {
+                                    throw new Error("Chains are required for EVM wallets");
+                                }
+                                return (walletClient as CrossmintEVMSmartWalletClient).tokenBalanceOf(currencies as SupportedEVMCurrency[], chains as any, wallet);
+                            }
+                            return (walletClient as CrossmintSolanaCustodialWalletClient).tokenBalanceOf(currencies as SupportedSolanaCurrency[], wallet);
+                        },
+                    },
+                ];
+            },
+        };
+    };
+}

--- a/typescript/packages/wallets/crossmint/src/faucet.ts
+++ b/typescript/packages/wallets/crossmint/src/faucet.ts
@@ -9,15 +9,6 @@ export const topUpBalanceParametersSchema = z.object({
     amount: z.number().min(1).max(100).describe("The amount of tokens to top up"),
 });
 
-export const getBalanceParametersSchema = z.object({
-    wallet: z.string().optional().describe("The address to check the balance of"),
-    currencies: z.array(z.enum(SUPPORTED_CURRENCIES))
-        .default(["usdc", "eth"])
-        .describe("The currencies to check the balance for"),
-    chains: z.array(z.string()).optional()
-        .describe("Optional specific chains to check balances on"),
-});
-
 export function faucetFactory(client: CrossmintApiClient) {
     return function faucet(): Plugin<EVMWalletClient> {
         return {
@@ -80,25 +71,6 @@ export function faucetFactory(client: CrossmintApiClient) {
                             }
 
                             throw new Error(`Failed to top up balance: ${await response.text()}`);
-                        },
-                    },
-                    {
-                        name: "check_balance",
-                        description: "This {{tool}} checks the balance of specified currencies in your wallet",
-                        parameters: getBalanceParametersSchema,
-                        method: async (
-                            walletClient: EVMWalletClient,
-                            parameters: z.infer<typeof getBalanceParametersSchema>,
-                        ) => {
-                            const wallet = parameters.wallet ?? walletClient.getAddress();
-                            const resolvedWalletAddress = await walletClient.resolveAddress(wallet);
-
-                            const balances = await client.getWalletBalance(resolvedWalletAddress, {
-                                currencies: parameters.currencies,
-                                chains: parameters.chains,
-                            });
-
-                            return balances;
                         },
                     },
                 ];

--- a/typescript/packages/wallets/crossmint/src/faucet.ts
+++ b/typescript/packages/wallets/crossmint/src/faucet.ts
@@ -2,7 +2,6 @@ import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
 import type { Chain, EVMWalletClient, Plugin } from "@goat-sdk/core";
 import { z } from "zod";
 import { isChainSupportedByFaucet } from "./chains";
-import { SUPPORTED_CURRENCIES, SupportedCurrency } from "./api";
 
 export const topUpBalanceParametersSchema = z.object({
     wallet: z.string().optional().describe("The address to top up the balance of"),

--- a/typescript/packages/wallets/crossmint/src/index.ts
+++ b/typescript/packages/wallets/crossmint/src/index.ts
@@ -3,6 +3,7 @@ import { custodialFactory } from "./custodial";
 import { faucetFactory } from "./faucet";
 import { mintingFactory } from "./mint";
 import { smartWalletFactory } from "./smart-wallet";
+import { balanceFactory } from "./balance";
 
 function crossmint(apiKey: string) {
     const apiClient = new CrossmintApiClient(
@@ -24,6 +25,7 @@ function crossmint(apiKey: string) {
         smartwallet: smartWalletFactory(apiClient),
         faucet: faucetFactory(apiClient),
         mint: mintingFactory(apiClient),
+        balance: balanceFactory(apiClient),
     };
 }
 

--- a/typescript/packages/wallets/crossmint/src/smart-wallet.ts
+++ b/typescript/packages/wallets/crossmint/src/smart-wallet.ts
@@ -1,4 +1,4 @@
-import type { EVMReadRequest, EVMSmartWalletClient, EVMTransaction, EVMTypedData } from "@goat-sdk/core";
+import type { EVMReadRequest, EVMSmartWalletClient as BaseEVMSmartWalletClient, EVMTransaction, EVMTypedData } from "@goat-sdk/core";
 
 import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
 import type { Abi } from "abitype";
@@ -6,7 +6,7 @@ import { http, createPublicClient, encodeFunctionData } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
 import { normalize } from "viem/ens";
-import { createCrossmintAPI } from "./api";
+import { createCrossmintAPI, SupportedCurrency } from "./api";
 import { type SupportedSmartWalletChains, getViemChain } from "./chains";
 
 export type CustodialSigner = `0x${string}`;
@@ -37,6 +37,13 @@ export type SmartWalletOptions = {
         ensProvider?: string;
     };
 };
+
+export interface EVMSmartWalletClient extends BaseEVMSmartWalletClient {
+    getTokenBalances(params?: { 
+        currencies?: SupportedCurrency[],
+        chains?: string[]
+    }): Promise<any>;
+}
 
 export function smartWalletFactory(crossmintClient: CrossmintApiClient) {
     return async function smartwallet(params: SmartWalletOptions): Promise<EVMSmartWalletClient> {
@@ -287,6 +294,15 @@ export function smartWalletFactory(crossmintClient: CrossmintApiClient) {
                     name: "Ethereum",
                     value: balance,
                 };
+            },
+            async getTokenBalances(params?: { 
+                currencies?: SupportedCurrency[],
+                chains?: string[]
+            }) {
+                return await client.getWalletBalance(address, {
+                    currencies: params?.currencies ?? ["usdc", "eth"],
+                    chains: params?.chains
+                });
             },
         };
     };


### PR DESCRIPTION
# Relates to:

# Background
Adds a new balance plugin for Crossmint wallets to fetch token balances using the Crossmint API. This plugin supports both EVM and Solana chains and integrates with the existing wallet infrastructure.

## What does this PR do?

- Implements a new balance plugin for Crossmint wallets
- Adds support for querying token balances across different chains
- Handles both EVM and Solana wallet types
- Provides error handling for failed balance queries

## What kind of change is this?
New feature (non-breaking change which adds functionality)

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->

# Testing

## Detailed testing steps

- Initialize a Crossmint wallet with the balance plugin
- Test balance queries with different tokens
- Test across both EVM and Solana chains to ensure proper functionality

## For plugins
- [ ] I have tested this change locally with key pair wallets
- [*] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)
