### PR TITLE
Add single sided pool creation on Orca

### DIFF
--- a/typescript/packages/plugins/orca/package.json
+++ b/typescript/packages/plugins/orca/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@goat-sdk/plugin-orca",
+    "version": "0.2.4",
+    "files": ["dist/**/*", "README.md", "package.json"],
+    "scripts": {
+        "build": "tsup",
+        "clean": "rm -rf dist",
+        "test": "vitest run --passWithNoTests"
+    },
+    "sideEffects": false,
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@goat-sdk/core": "workspace:*",
+        "@goat-sdk/wallet-solana": "workspace:*",
+        "@orca-so/common-sdk": "0.6.5-beta.3",
+        "@orca-so/whirlpools-sdk": "0.13.12",
+        "@solana/spl-token": "0.4.9",
+        "@solana/web3.js": "catalog:",
+        "decimal.js": "10.4.3",
+        "zod": "catalog:"
+    },
+    "peerDependencies": {
+        "@goat-sdk/core": "workspace:*"
+    },
+    "homepage": "https://ohmygoat.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/goat-sdk/goat.git"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/goat-sdk/goat/issues"
+    },
+    "keywords": ["ai", "agents", "web3"]
+}

--- a/typescript/packages/plugins/orca/src/index.ts
+++ b/typescript/packages/plugins/orca/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./orca.plugin";
+export * from "./parameters";

--- a/typescript/packages/plugins/orca/src/orca.plugin.ts
+++ b/typescript/packages/plugins/orca/src/orca.plugin.ts
@@ -1,0 +1,12 @@
+import { type Chain, PluginBase } from "@goat-sdk/core";
+import { OrcaService } from "./orca.service";
+
+export class OrcaPlugin extends PluginBase {
+    constructor() {
+        super("orca", [new OrcaService()]);
+    }
+
+    supportsChain = (chain: Chain) => chain.type === "solana";
+}
+
+export const orca = () => new OrcaPlugin();

--- a/typescript/packages/plugins/orca/src/orca.service.ts
+++ b/typescript/packages/plugins/orca/src/orca.service.ts
@@ -1,0 +1,292 @@
+import { BN, Wallet } from "@coral-xyz/anchor";
+import { Tool } from "@goat-sdk/core";
+import { SolanaWalletClient } from "@goat-sdk/wallet-solana";
+import { Percentage, TransactionBuilder, resolveOrCreateATAs } from "@orca-so/common-sdk";
+import {
+    IncreaseLiquidityQuoteParam,
+    NO_TOKEN_EXTENSION_CONTEXT,
+    ORCA_WHIRLPOOL_PROGRAM_ID,
+    PDAUtil,
+    PoolUtil,
+    PriceMath,
+    TickUtil,
+    TokenExtensionContextForPool,
+    TokenExtensionUtil,
+    //   ORCA_WHIRLPOOLS_CONFIG,
+    WhirlpoolContext,
+    WhirlpoolIx,
+    increaseLiquidityQuoteByInputTokenWithParams,
+} from "@orca-so/whirlpools-sdk";
+import {
+    increaseLiquidityIx,
+    increaseLiquidityV2Ix,
+    initTickArrayIx,
+    openPositionWithTokenExtensionsIx,
+} from "@orca-so/whirlpools-sdk/dist/instructions";
+import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { Decimal } from "decimal.js";
+import { CreateSingleSidedPoolParameters } from "./parameters";
+
+export const FEE_TIERS = {
+    0.01: 1,
+    0.02: 2,
+    0.04: 4,
+    0.05: 8,
+    0.16: 16,
+    0.3: 64,
+    0.65: 96,
+    1.0: 128,
+    2.0: 256,
+} as const;
+
+const ORCA_WHIRLPOOLS_CONFIG = new PublicKey("FcrweFY1G9HJAHG5inkGB6pKg1HZ6x9UC2WioAfWrGkR");
+
+export class OrcaService {
+    @Tool({
+        description:
+            "Create a single-sided liquidity pool on the Orca DEX. This function initializes a new pool with liquidity contributed from a single token, allowing users to define an initial price, a maximum price, and other parameters. The function ensures proper mint order and on-chain configuration for seamless execution. Ideal for setting up a pool with minimal price impact, it supports advanced features like adjustable fee tiers and precise initial price settings.",
+    })
+    async createSingleSidedPool(walletClient: SolanaWalletClient, parameters: CreateSingleSidedPoolParameters) {
+        const vanityWallet = new Wallet(new Keypair());
+        const ctx = WhirlpoolContext.from(walletClient.getConnection(), vanityWallet, ORCA_WHIRLPOOL_PROGRAM_ID);
+        const fetcher = ctx.fetcher;
+        const walletAddress = new PublicKey(walletClient.getAddress());
+
+        const depositTokenAmount = new BN(Number(parameters.depositTokenAmount));
+        const depositTokenMint = new PublicKey(parameters.depositTokenMint);
+        const otherTokenMint = new PublicKey(parameters.otherTokenMint);
+        let initialPrice = new Decimal(Number(parameters.startPrice));
+        let maxPrice = new Decimal(Number(parameters.maxPrice));
+        const feeTier = Number(parameters.feeTier) as keyof typeof FEE_TIERS;
+
+        const correctTokenOrder = PoolUtil.orderMints(otherTokenMint, depositTokenMint).map((addr) => addr.toString());
+        const isCorrectMintOrder = correctTokenOrder[0] === depositTokenMint.toString();
+        let mintA: PublicKey;
+        let mintB: PublicKey;
+        if (isCorrectMintOrder) {
+            [mintA, mintB] = [depositTokenMint, otherTokenMint];
+        } else {
+            [mintA, mintB] = [otherTokenMint, depositTokenMint];
+            initialPrice = new Decimal(1 / initialPrice.toNumber());
+            maxPrice = new Decimal(1 / maxPrice.toNumber());
+        }
+        const mintAAccount = await fetcher.getMintInfo(mintA);
+        const mintBAccount = await fetcher.getMintInfo(mintB);
+        if (mintAAccount === null || mintBAccount === null) throw Error("Mint account not found");
+        const tickSpacing = FEE_TIERS[feeTier];
+        const tickIndex = PriceMath.priceToTickIndex(initialPrice, mintAAccount.decimals, mintBAccount.decimals);
+        const initialTick = TickUtil.getInitializableTickIndex(tickIndex, tickSpacing);
+
+        const tokenExtensionCtx: TokenExtensionContextForPool = {
+            ...NO_TOKEN_EXTENSION_CONTEXT,
+            tokenMintWithProgramA: mintAAccount,
+            tokenMintWithProgramB: mintBAccount,
+        };
+        const feeTierKey = PDAUtil.getFeeTier(ORCA_WHIRLPOOL_PROGRAM_ID, ORCA_WHIRLPOOLS_CONFIG, tickSpacing).publicKey;
+        const initSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(initialTick);
+        const tokenVaultAKeypair = Keypair.generate();
+        const tokenVaultBKeypair = Keypair.generate();
+        const whirlpoolPda = PDAUtil.getWhirlpool(
+            ORCA_WHIRLPOOL_PROGRAM_ID,
+            ORCA_WHIRLPOOLS_CONFIG,
+            mintA,
+            mintB,
+            FEE_TIERS[feeTier],
+        );
+        const tokenBadgeA = PDAUtil.getTokenBadge(ORCA_WHIRLPOOL_PROGRAM_ID, ORCA_WHIRLPOOLS_CONFIG, mintA).publicKey;
+        const tokenBadgeB = PDAUtil.getTokenBadge(ORCA_WHIRLPOOL_PROGRAM_ID, ORCA_WHIRLPOOLS_CONFIG, mintB).publicKey;
+        const baseParamsPool = {
+            initSqrtPrice,
+            whirlpoolsConfig: ORCA_WHIRLPOOLS_CONFIG,
+            whirlpoolPda,
+            tokenMintA: mintA,
+            tokenMintB: mintB,
+            tokenVaultAKeypair,
+            tokenVaultBKeypair,
+            feeTierKey,
+            tickSpacing: tickSpacing,
+            funder: walletAddress,
+        };
+        const initPoolIx = !TokenExtensionUtil.isV2IxRequiredPool(tokenExtensionCtx)
+            ? WhirlpoolIx.initializePoolIx(ctx.program, baseParamsPool)
+            : WhirlpoolIx.initializePoolV2Ix(ctx.program, {
+                  ...baseParamsPool,
+                  tokenProgramA: tokenExtensionCtx.tokenMintWithProgramA.tokenProgram,
+                  tokenProgramB: tokenExtensionCtx.tokenMintWithProgramB.tokenProgram,
+                  tokenBadgeA,
+                  tokenBadgeB,
+              });
+        const initialTickArrayStartTick = TickUtil.getStartTickIndex(initialTick, tickSpacing);
+        const initialTickArrayPda = PDAUtil.getTickArray(
+            ctx.program.programId,
+            whirlpoolPda.publicKey,
+            initialTickArrayStartTick,
+        );
+
+        const txBuilder = new TransactionBuilder(ctx.provider.connection, ctx.provider.wallet, ctx.txBuilderOpts);
+        txBuilder.addInstruction(initPoolIx);
+        txBuilder.addInstruction(
+            initTickArrayIx(ctx.program, {
+                startTick: initialTickArrayStartTick,
+                tickArrayPda: initialTickArrayPda,
+                whirlpool: whirlpoolPda.publicKey,
+                funder: walletAddress,
+            }),
+        );
+
+        let tickLowerIndex: number;
+        let tickUpperIndex: number;
+        if (isCorrectMintOrder) {
+            tickLowerIndex = initialTick;
+            tickUpperIndex = PriceMath.priceToTickIndex(maxPrice, mintAAccount.decimals, mintBAccount.decimals);
+        } else {
+            tickLowerIndex = PriceMath.priceToTickIndex(maxPrice, mintAAccount.decimals, mintBAccount.decimals);
+            tickUpperIndex = initialTick;
+        }
+        const tickLowerInitializableIndex = TickUtil.getInitializableTickIndex(tickLowerIndex, tickSpacing);
+        const tickUpperInitializableIndex = TickUtil.getInitializableTickIndex(tickUpperIndex, tickSpacing);
+        if (
+            !TickUtil.checkTickInBounds(tickLowerInitializableIndex) ||
+            !TickUtil.checkTickInBounds(tickUpperInitializableIndex)
+        )
+            throw Error("Prices out of bounds");
+        const increasLiquidityQuoteParam: IncreaseLiquidityQuoteParam = {
+            inputTokenAmount: depositTokenAmount,
+            inputTokenMint: depositTokenMint,
+            tokenMintA: mintA,
+            tokenMintB: mintB,
+            tickCurrentIndex: initialTick,
+            sqrtPrice: initSqrtPrice,
+            tickLowerIndex: tickLowerInitializableIndex,
+            tickUpperIndex: tickUpperInitializableIndex,
+            tokenExtensionCtx: tokenExtensionCtx,
+            slippageTolerance: Percentage.fromFraction(0, 100),
+        };
+        const liquidityInput = increaseLiquidityQuoteByInputTokenWithParams(increasLiquidityQuoteParam);
+        const { liquidityAmount: liquidity, tokenMaxA, tokenMaxB } = liquidityInput;
+
+        const positionMintKeypair = Keypair.generate();
+        const positionMintPubkey = positionMintKeypair.publicKey;
+        const positionPda = PDAUtil.getPosition(ORCA_WHIRLPOOL_PROGRAM_ID, positionMintPubkey);
+        const positionTokenAccountAddress = getAssociatedTokenAddressSync(
+            positionMintPubkey,
+            walletAddress,
+            ctx.accountResolverOpts.allowPDAOwnerAddress,
+            TOKEN_2022_PROGRAM_ID,
+        );
+        const params = {
+            funder: walletAddress,
+            owner: walletAddress,
+            positionPda,
+            positionTokenAccount: positionTokenAccountAddress,
+            whirlpool: whirlpoolPda.publicKey,
+            tickLowerIndex: tickLowerInitializableIndex,
+            tickUpperIndex: tickUpperInitializableIndex,
+        };
+        const positionIx = openPositionWithTokenExtensionsIx(ctx.program, {
+            ...params,
+            positionMint: positionMintPubkey,
+            withTokenMetadataExtension: true,
+        });
+
+        txBuilder.addInstruction(positionIx);
+        txBuilder.addSigner(positionMintKeypair);
+
+        const [ataA, ataB] = await resolveOrCreateATAs(
+            ctx.connection,
+            walletAddress,
+            [
+                { tokenMint: mintA, wrappedSolAmountIn: tokenMaxA },
+                { tokenMint: mintB, wrappedSolAmountIn: tokenMaxB },
+            ],
+            () => ctx.fetcher.getAccountRentExempt(),
+            walletAddress,
+            undefined,
+            ctx.accountResolverOpts.allowPDAOwnerAddress,
+            ctx.accountResolverOpts.createWrappedSolAccountMethod,
+        );
+        const { address: tokenOwnerAccountA, ...tokenOwnerAccountAIx } = ataA;
+        const { address: tokenOwnerAccountB, ...tokenOwnerAccountBIx } = ataB;
+
+        txBuilder.addInstruction(tokenOwnerAccountAIx);
+        txBuilder.addInstruction(tokenOwnerAccountBIx);
+
+        const tickArrayLowerStartIndex = TickUtil.getStartTickIndex(tickLowerInitializableIndex, tickSpacing);
+        const tickArrayUpperStartIndex = TickUtil.getStartTickIndex(tickUpperInitializableIndex, tickSpacing);
+        const tickArrayLowerPda = PDAUtil.getTickArray(
+            ctx.program.programId,
+            whirlpoolPda.publicKey,
+            tickArrayLowerStartIndex,
+        );
+        const tickArrayUpperPda = PDAUtil.getTickArray(
+            ctx.program.programId,
+            whirlpoolPda.publicKey,
+            tickArrayUpperStartIndex,
+        );
+        if (tickArrayUpperStartIndex !== tickArrayLowerStartIndex) {
+            if (isCorrectMintOrder) {
+                txBuilder.addInstruction(
+                    initTickArrayIx(ctx.program, {
+                        startTick: tickArrayUpperStartIndex,
+                        tickArrayPda: tickArrayUpperPda,
+                        whirlpool: whirlpoolPda.publicKey,
+                        funder: walletAddress,
+                    }),
+                );
+            } else {
+                txBuilder.addInstruction(
+                    initTickArrayIx(ctx.program, {
+                        startTick: tickArrayLowerStartIndex,
+                        tickArrayPda: tickArrayLowerPda,
+                        whirlpool: whirlpoolPda.publicKey,
+                        funder: walletAddress,
+                    }),
+                );
+            }
+        }
+
+        const baseParamsLiquidity = {
+            liquidityAmount: liquidity,
+            tokenMaxA,
+            tokenMaxB,
+            whirlpool: whirlpoolPda.publicKey,
+            positionAuthority: walletAddress,
+            position: positionPda.publicKey,
+            positionTokenAccount: positionTokenAccountAddress,
+            tokenOwnerAccountA,
+            tokenOwnerAccountB,
+            tokenVaultA: tokenVaultAKeypair.publicKey,
+            tokenVaultB: tokenVaultBKeypair.publicKey,
+            tickArrayLower: tickArrayLowerPda.publicKey,
+            tickArrayUpper: tickArrayUpperPda.publicKey,
+        };
+
+        const liquidityIx = !TokenExtensionUtil.isV2IxRequiredPool(tokenExtensionCtx)
+            ? increaseLiquidityIx(ctx.program, baseParamsLiquidity)
+            : increaseLiquidityV2Ix(ctx.program, {
+                  ...baseParamsLiquidity,
+                  tokenMintA: mintA,
+                  tokenMintB: mintB,
+                  tokenProgramA: tokenExtensionCtx.tokenMintWithProgramA.tokenProgram,
+                  tokenProgramB: tokenExtensionCtx.tokenMintWithProgramB.tokenProgram,
+              });
+        txBuilder.addInstruction(liquidityIx);
+
+        const txPayload = await txBuilder.build({
+            maxSupportedTransactionVersion: "legacy",
+        });
+
+        if (txPayload.transaction instanceof Transaction) {
+            try {
+                const { hash } = await walletClient.sendTransaction({
+                    instructions: txPayload.transaction.instructions,
+                    accountsToSign: [positionMintKeypair, tokenVaultAKeypair, tokenVaultBKeypair],
+                });
+                return hash;
+            } catch (error) {
+                throw new Error(`Failed to create pool: ${JSON.stringify(error)}`);
+            }
+        }
+    }
+}

--- a/typescript/packages/plugins/orca/src/parameters.ts
+++ b/typescript/packages/plugins/orca/src/parameters.ts
@@ -1,0 +1,22 @@
+import { createToolParameters } from "@goat-sdk/core";
+import { z } from "zod";
+
+export class CreateSingleSidedPoolParameters extends createToolParameters(
+    z.object({
+        depositTokenAmount: z
+            .string()
+            .describe("The amount of the deposit token (including the decimals) to contribute to the pool."),
+        depositTokenMint: z
+            .string()
+            .describe("The mint address of the token being deposited into the pool, eg. NEW_TOKEN."),
+        otherTokenMint: z.string().describe("The mint address of the other token in the pool, eg. USDC."),
+        startPrice: z
+            .string()
+            .describe("The initial start price of the deposit token in terms of the other token, eg. 0.001 USDC."),
+        maxPrice: z.string().describe("The initial maximum price of the token."),
+        feeTier: z.string().describe(
+            "The fee tier percentage for the pool, determining tick spacing and fee collection rates. \
+            Available fee tiers are 0.01, 0.02, 0.04, 0.05, 0.16, 0.30, 0.65, 1.0, 2.0",
+        ),
+    }),
+) {}

--- a/typescript/packages/plugins/orca/tsconfig.json
+++ b/typescript/packages/plugins/orca/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../../tsconfig.base.json",
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/plugins/orca/tsup.config.ts
+++ b/typescript/packages/plugins/orca/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { treeShakableConfig } from "../../../tsup.config.base";
+
+export default defineConfig({
+    ...treeShakableConfig,
+});

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -698,7 +698,7 @@ importers:
         version: link:../../wallets/solana
       '@meteora-ag/dlmm':
         specifier: 1.3.4
-        version: 1.3.4(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)
+        version: 1.3.4(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: 'catalog:'
         version: 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -712,6 +712,36 @@ importers:
       '@types/bn.js':
         specifier: 5.1.6
         version: 5.1.6
+
+  packages/plugins/orca:
+    dependencies:
+      '@coral-xyz/anchor':
+        specifier: 0.29.0
+        version: 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@goat-sdk/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@goat-sdk/wallet-solana':
+        specifier: workspace:*
+        version: link:../../wallets/solana
+      '@orca-so/common-sdk':
+        specifier: 0.6.5-beta.3
+        version: 0.6.5-beta.3(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3)
+      '@orca-so/whirlpools-sdk':
+        specifier: 0.13.12
+        version: 0.13.12(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@orca-so/common-sdk@0.6.5-beta.3(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3))(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3)
+      '@solana/spl-token':
+        specifier: 0.4.9
+        version: 0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js':
+        specifier: 'catalog:'
+        version: 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      decimal.js:
+        specifier: 10.4.3
+        version: 10.4.3
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
 
   packages/plugins/polymarket:
     dependencies:
@@ -1987,12 +2017,22 @@ packages:
     resolution: {integrity: sha512-kQ02Hv2ZqxtWP30WN1d4xxT4QqlOXYDxmEd3k/bbneqhV3X5QMO4LAtoUFs7otxyivOgoqam5Il5qx81FuI4vw==}
     engines: {node: '>=11'}
 
+  '@coral-xyz/anchor@0.29.0':
+    resolution: {integrity: sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==}
+    engines: {node: '>=11'}
+
   '@coral-xyz/anchor@0.30.1':
     resolution: {integrity: sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==}
     engines: {node: '>=11'}
 
   '@coral-xyz/borsh@0.28.0':
     resolution: {integrity: sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
+
+  '@coral-xyz/borsh@0.29.0':
+    resolution: {integrity: sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.68.0
@@ -3339,6 +3379,22 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@orca-so/common-sdk@0.6.5-beta.3':
+    resolution: {integrity: sha512-k+luSLr/kcbXEcw3PqJRYZZHWn9gM/I3QbkVPnQDFAwUXkSsi9Uwb8tF2Gr16oCpyr8BthWlJC2O0MXEx1yt4w==}
+    peerDependencies:
+      '@solana/spl-token': ^0.4.1
+      '@solana/web3.js': ^1.90.0
+      decimal.js: ^10.4.3
+
+  '@orca-so/whirlpools-sdk@0.13.12':
+    resolution: {integrity: sha512-+LOqGTe0DYUsYwemltOU4WQIviqoICQlIcAmmEX/WnBh6wntpcLDcXkPV6dBHW7NA2/J8WEVAZ50biLJb4subg==}
+    peerDependencies:
+      '@coral-xyz/anchor': ~0.29.0
+      '@orca-so/common-sdk': 0.6.4
+      '@solana/spl-token': ^0.4.8
+      '@solana/web3.js': ^1.90.0
+      decimal.js: ^10.4.3
 
   '@parcel/watcher-android-arm64@2.5.0':
     resolution: {integrity: sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==}
@@ -8135,6 +8191,9 @@ packages:
     resolution: {integrity: sha512-pqqJOi1rF5zNs/ps4vmbE4SFCrM4iR7LW+GHAsHqO/EumqbIWceioevYLM5xZRgQSH6gFgL9J/uB7EcJhQ9niQ==}
     engines: {node: '>=0.10.0'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
@@ -10256,6 +10315,27 @@ snapshots:
       - encoding
       - utf-8-validate
 
+  '@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@noble/hashes': 1.6.1
+      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      bn.js: 5.2.1
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.1.8
+      crypto-hash: 1.3.0
+      eventemitter3: 4.0.7
+      pako: 2.1.0
+      snake-case: 3.0.4
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
   '@coral-xyz/anchor@0.30.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor-errors': 0.30.1
@@ -10279,6 +10359,12 @@ snapshots:
       - utf-8-validate
 
   '@coral-xyz/borsh@0.28.0(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      bn.js: 5.2.1
+      buffer-layout: 1.2.2
+
+  '@coral-xyz/borsh@0.29.0(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
@@ -12389,11 +12475,11 @@ snapshots:
       '@metaplex-foundation/umi-public-keys': 0.8.9
       '@metaplex-foundation/umi-serializers': 0.9.0
 
-  '@meteora-ag/dlmm@1.3.4(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)':
+  '@meteora-ag/dlmm@1.3.4(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.28.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@solana-developers/helpers': 2.5.6(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana-developers/helpers': 2.5.6(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/buffer-layout': 4.0.1
       '@solana/spl-token': 0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -12536,6 +12622,22 @@ snapshots:
       sprintf-js: 1.1.3
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@orca-so/common-sdk@0.6.5-beta.3(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3)':
+    dependencies:
+      '@solana/spl-token': 0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      decimal.js: 10.4.3
+      tiny-invariant: 1.3.3
+
+  '@orca-so/whirlpools-sdk@0.13.12(@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@orca-so/common-sdk@0.6.5-beta.3(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3))(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3)':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@orca-so/common-sdk': 0.6.5-beta.3(@solana/spl-token@0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(decimal.js@10.4.3)
+      '@solana/spl-token': 0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      decimal.js: 10.4.3
+      tiny-invariant: 1.3.3
 
   '@parcel/watcher-android-arm64@2.5.0':
     optional: true
@@ -13049,7 +13151,7 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-developers/helpers@2.5.6(bufferutil@4.0.8)(typescript@5.6.3)(utf-8-validate@5.0.10)':
+  '@solana-developers/helpers@2.5.6(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/spl-token': 0.4.9(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.95.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
@@ -18905,6 +19007,8 @@ snapshots:
   through@2.3.8: {}
 
   timed-out@2.0.0: {}
+
+  tiny-invariant@1.3.3: {}
 
   tiny-warning@1.0.3: {}
 


### PR DESCRIPTION
# Background

## What does this PR do?
Allows the  agent to create single sided pools on Orca.

## What kind of change is this?
New plugin

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Detailed testing steps
I used the branch `joyce-branch` and used the conversational agent in `GOAT/typescript/examples/vercel-ai/solana` to test pool creation. Here's a sample conversation with the agent and Devnet transaction:

https://solscan.io/tx/5BJ5UkomwKeUGSCLscJU4rWEZy3n75KeSyeBPg6JiQnQP3HG2FhdueXjGdtMGxuCJFukgBM9kHKMLSP5emJb15dK?cluster=devnet

![Screenshot 2024-12-20 035321](https://github.com/user-attachments/assets/369c7388-5de8-4d33-bf97-35dd33c425da)

## For plugins
- [x] I have tested this change locally with key pair wallets
- [ ] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)

## Discord username
@calintje