### PR TITLE
feat(plugin): add Mode Staking

### DIFF
--- a/goat.code-workspace
+++ b/goat.code-workspace
@@ -82,6 +82,10 @@
             "name": "[Plugin] 🦄 uniswap",
             "path": "./typescript/packages/plugins/uniswap"
         },
+        {
+            "name": "[Plugin] Mode staking",
+            "path": "./typescript/packages/plugins/mode-staking"
+        },
         // Wallets
         {
             "name": "[Wallet] 🅰 aptos",

--- a/typescript/examples/vercel-ai/mode-staking/.env.template
+++ b/typescript/examples/vercel-ai/mode-staking/.env.template
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=
+WALLET_PRIVATE_KEY=
+RPC_PROVIDER_URL=https://mainnet.mode.network

--- a/typescript/examples/vercel-ai/mode-staking/CHANGELOG.md
+++ b/typescript/examples/vercel-ai/mode-staking/CHANGELOG.md
@@ -1,0 +1,3 @@
+# goat-examples-vercel-ai-mode-staking
+
+## 0.1.0

--- a/typescript/examples/vercel-ai/mode-staking/README.md
+++ b/typescript/examples/vercel-ai/mode-staking/README.md
@@ -1,0 +1,40 @@
+# Mode Staking Example
+
+Example of using the Mode Staking plugin with GOAT SDK and GPT-4 to manage Mode DAO staking positions.
+
+## Setup
+
+1. Copy `.env.template` to `.env`:
+```bash
+cp .env.template .env
+```
+
+2. Fill in the environment variables in `.env`:
+- `OPENAI_API_KEY`: Your OpenAI API key
+- `WALLET_PRIVATE_KEY`: Your wallet's private key (with MODE tokens)
+- `RPC_PROVIDER_URL`: Mode Network RPC URL (defaults to https://mainnet.mode.network)
+
+3. Install dependencies:
+```bash
+npm install
+```
+
+4. Run the example:
+```bash
+npm start
+```
+
+## Example Tasks
+
+The example demonstrates several staking operations:
+1. Viewing current staking positions
+2. Staking MODE tokens with maximum duration
+3. Checking cooldown periods
+4. Increasing stake amounts
+5. Extending lock durations
+
+## Important Notes
+
+- Make sure your wallet has sufficient MODE tokens
+- The Mode Network must be operational
+- The wallet must have enough ETH for gas fees

--- a/typescript/examples/vercel-ai/mode-staking/index.ts
+++ b/typescript/examples/vercel-ai/mode-staking/index.ts
@@ -1,0 +1,55 @@
+import { openai } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+import { http } from "viem";
+import { createWalletClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { mode } from "./mode-chain";
+
+import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
+import { modeStaking } from "@goat-sdk/plugin-mode-staking";
+import { viem } from "@goat-sdk/wallet-viem";
+
+require("dotenv").config();
+
+const account = privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as `0x${string}`);
+
+const walletClient = createWalletClient({
+    account: account,
+    transport: http(process.env.RPC_PROVIDER_URL),
+    chain: mode, // Using Mode Network configuration
+});
+
+(async () => {
+    const tools = await getOnChainTools({
+        wallet: viem(walletClient),
+        plugins: [
+            modeStaking(),
+        ],
+    });
+
+    // Example tasks that demonstrate different staking operations
+    const tasks = [
+        "Show me all my current staking positions in the Mode DAO.",
+        "I want to stake 1000 MODE tokens for the maximum duration of 52 weeks.",
+        "What's the cooldown period for my staking position #1?",
+        "Can you increase my stake in position #1 by adding 500 more MODE tokens?",
+        "I'd like to extend the lock time of position #1 by 26 more weeks.",
+    ];
+
+    // Execute each task
+    for (const task of tasks) {
+        console.log("\nTask:", task);
+        try {
+            const result = await generateText({
+                model: openai("gpt-4"),
+                tools: tools,
+                maxSteps: 5,
+                prompt: task,
+            });
+            console.log("Result:", result.text);
+        } catch (error) {
+            console.error("Error executing task:", error);
+        }
+    }
+})();

--- a/typescript/examples/vercel-ai/mode-staking/mode-chain.ts
+++ b/typescript/examples/vercel-ai/mode-staking/mode-chain.ts
@@ -1,0 +1,25 @@
+import { defineChain } from "viem";
+
+export const mode = defineChain({
+    id: 34443,
+    name: "Mode",
+    network: "mode",
+    nativeCurrency: {
+        decimals: 18,
+        name: "Ether",
+        symbol: "ETH",
+    },
+    rpcUrls: {
+        default: { http: ["https://mainnet.mode.network"] },
+        public: { http: ["https://mainnet.mode.network"] },
+    },
+    blockExplorers: {
+        default: { name: "Mode Explorer", url: "https://explorer.mode.network" },
+    },
+    contracts: {
+        multicall3: {
+            address: "0xca11bde05977b3631167028862be2a173976ca11",
+            blockCreated: 1,
+        },
+    },
+});

--- a/typescript/examples/vercel-ai/mode-staking/package.json
+++ b/typescript/examples/vercel-ai/mode-staking/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "goat-examples-vercel-ai-mode-staking",
+    "version": "0.1.0",
+    "description": "",
+    "private": true,
+    "scripts": {
+        "test": "vitest run --passWithNoTests"
+    },
+    "author": "",
+    "license": "MIT",
+    "dependencies": {
+        "@ai-sdk/openai": "^1.0.4",
+        "@goat-sdk/adapter-vercel-ai": "workspace:*",
+        "@goat-sdk/core": "workspace:*",
+        "@goat-sdk/plugin-coingecko": "workspace:*",
+        "@goat-sdk/wallet-viem": "workspace:*",
+        "ai": "catalog:",
+        "dotenv": "^16.4.5",
+        "viem": "2.21.49"
+    }
+}

--- a/typescript/examples/vercel-ai/mode-staking/tsconfig.json
+++ b/typescript/examples/vercel-ai/mode-staking/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": ["index.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/plugins/mode-staking/CHANGELOG.md
+++ b/typescript/packages/plugins/mode-staking/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @goat-sdk/plugin-mode-staking
+
+## 0.1.0

--- a/typescript/packages/plugins/mode-staking/README.md
+++ b/typescript/packages/plugins/mode-staking/README.md
@@ -1,0 +1,89 @@
+# Goat Mode Staking Plugin 🐐
+
+Mode staking plugin for Goat. Allows agents to stake MODE tokens, manage staking positions, and track cooldown/warmup periods.
+
+## Installation
+```bash
+npm install @goat-sdk/plugin-mode-staking
+```
+
+## Usage
+
+```typescript
+import { modeStaking } from "@goat-sdk/plugin-mode-staking";
+import { getOnChainTools } from '@goat-sdk/adapter-vercel-ai';
+
+const tools = getOnChainTools({
+    wallet: viem(wallet),
+    plugins: [
+        modeStaking(),
+    ],
+});
+```
+
+## Features
+
+### Staking Operations
+- Stake MODE tokens with customizable lock duration
+- Unstake tokens from existing positions
+- Increase staked amount for existing positions
+- Extend lock duration for existing positions
+
+### Position Management
+- View all staking positions for a wallet
+- Check position details including:
+  - Staked amount
+  - Lock end time
+  - Current voting power
+
+### Timelock Information
+- Check cooldown period status and remaining time
+- Check warmup period status and remaining time
+
+## Contract Addresses
+
+- MODE Token: `0xDfc7C877a950e49D2610114102175A06C2e3167a`
+- Voting Escrow: `0xff8AB822b8A853b01F9a9E9465321d6Fe77c9D2F`
+- veNFT Lock: `0x06ab1Dc3c330E9CeA4fDF0C7C6F6Fb6442A4273C`
+- Exit Queue: `0x915e50A7C53e05F72122bC883309a812A90bA163`
+- Clock: `0x66CC481755f8a9d415e75d29C17B0E3eF2Af70bD`
+
+## Example Prompts
+
+```
+"Stake 1000 MODE tokens for 52 weeks"
+"Check all my current staking positions"
+"Increase my stake in position #123 by 500 MODE"
+"Extend lock time for position #123 by 26 weeks"
+"Check cooldown period for position #123"
+"Check warmup period for position #123"
+"Unstake my tokens from position #123"
+```
+
+## Important Notes
+
+### Lock Duration
+- Maximum lock duration is 52 weeks
+- Longer lock duration results in higher voting power
+- Lock duration cannot be reduced, only extended
+
+### Cooldown and Warmup
+- Positions have cooldown periods when unstaking
+- New positions have warmup periods before gaining full voting power
+- These periods cannot be bypassed
+
+### Voting Power
+- Voting power depends on amount staked and lock duration
+- Higher amounts and longer locks = more voting power
+- Voting power decays linearly as lock expiration approaches
+
+## Goat
+
+<div align="center">
+Go out and eat some grass.
+
+[Docs](https://ohmygoat.dev) | [Examples](https://github.com/goat-sdk/goat/tree/main/typescript/examples) | [Discord](https://discord.gg/goat-sdk)
+</div>
+
+## Contributing
+Please follow the standard Goat contribution guidelines. Submit issues and PRs on the main Goat repository.

--- a/typescript/packages/plugins/mode-staking/package.json
+++ b/typescript/packages/plugins/mode-staking/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "@goat-sdk/plugin-mode-staking",
+    "version": "0.1.0",
+    "description": "Mode staking plugin for GOAT SDK",
+    "files": ["dist/**/*", "README.md", "package.json"],
+    "scripts": {
+        "build": "tsup",
+        "clean": "rm -rf dist",
+        "test": "vitest run --passWithNoTests"
+    },
+    "sideEffects": false,
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "dependencies": {
+        "@goat-sdk/core": "workspace:*",
+        "zod": "catalog:"
+    },
+    "peerDependencies": {
+        "@goat-sdk/core": "workspace:*"
+    },
+    "homepage": "https://ohmygoat.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/goat-sdk/goat.git"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/goat-sdk/goat/issues"
+    },
+    "keywords": ["ai", "agents", "web3", "staking"]
+}

--- a/typescript/packages/plugins/mode-staking/src/constants/index.ts
+++ b/typescript/packages/plugins/mode-staking/src/constants/index.ts
@@ -1,0 +1,33 @@
+import { parseAbi } from "viem";
+
+export const MODE_TOKEN_ABI = parseAbi([
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function allowance(address owner, address spender) external view returns (uint256)",
+    "function balanceOf(address account) external view returns (uint256)",
+]);
+
+export const VOTING_ESCROW_ABI = parseAbi([
+    "function create_lock(uint256 amount, uint256 unlock_time) external returns (uint256)",
+    "function increase_amount(uint256 tokenId, uint256 amount) external",
+    "function increase_unlock_time(uint256 tokenId, uint256 unlock_time) external",
+    "function withdraw(uint256 tokenId) external",
+    "function balanceOfNFT(uint256 tokenId) external view returns (uint256)",
+    "function locked(uint256 tokenId) external view returns (int128 amount, uint256 end)",
+]);
+
+export const VENFT_LOCK_ABI = parseAbi([
+    "function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256)",
+    "function balanceOf(address owner) external view returns (uint256)",
+]);
+
+export const EXIT_QUEUE_ABI = parseAbi([
+    "function cooldowns(uint256 tokenId) external view returns (uint256)",
+    "function warmups(uint256 tokenId) external view returns (uint256)",
+    "function MIN_COOLDOWN() external view returns (uint256)",
+    "function MIN_WARMUP() external view returns (uint256)",
+]);
+
+export const CLOCK_ABI = parseAbi([
+    "function epoch() external view returns (uint256)",
+    "function EPOCH_INTERVAL() external view returns (uint256)",
+]);

--- a/typescript/packages/plugins/mode-staking/src/index.ts
+++ b/typescript/packages/plugins/mode-staking/src/index.ts
@@ -1,0 +1,3 @@
+export * from './mode-staking.plugin';
+export * from './parameters';
+export * from './types';

--- a/typescript/packages/plugins/mode-staking/src/mode-staking.plugin.ts
+++ b/typescript/packages/plugins/mode-staking/src/mode-staking.plugin.ts
@@ -1,0 +1,18 @@
+import { type Chain, PluginBase } from "@goat-sdk/core";
+import type { EVMWalletClient } from "@goat-sdk/wallet-evm";
+import { MODE_CHAIN_ID } from "./types";
+import { getTools } from "./mode-staking.service";
+
+export class ModeStakingPlugin extends PluginBase<EVMWalletClient> {
+    constructor() {
+        super("modeStaking", []);
+    }
+
+    supportsChain = (chain: Chain) => chain.type === "evm" && chain.id === MODE_CHAIN_ID;
+
+    getTools(walletClient: EVMWalletClient) {
+        return getTools(walletClient);
+    }
+}
+
+export const modeStaking = () => new ModeStakingPlugin();

--- a/typescript/packages/plugins/mode-staking/src/mode-staking.service.ts
+++ b/typescript/packages/plugins/mode-staking/src/mode-staking.service.ts
@@ -1,0 +1,237 @@
+import { type ToolBase, createTool } from "@goat-sdk/core";
+import type { EVMWalletClient } from "@goat-sdk/wallet-evm";
+import type { z } from "zod";
+import {
+    MODE_TOKEN_ABI,
+    VOTING_ESCROW_ABI,
+    VENFT_LOCK_ABI,
+    EXIT_QUEUE_ABI,
+    CLOCK_ABI,
+} from "./constants";
+import { MODE_CONTRACTS } from "./types";
+import {
+    stakeParametersSchema,
+    unstakeParametersSchema,
+    increaseAmountParametersSchema,
+    increaseLockTimeParametersSchema,
+    getStakingPositionParametersSchema,
+    getStakingPositionsParametersSchema,
+    getCooldownInfoParametersSchema,
+    getWarmupInfoParametersSchema,
+} from "./parameters";
+
+export function getTools(walletClient: EVMWalletClient): ToolBase[] {
+    return [
+        // Stake MODE tokens
+        createTool(
+            {
+                name: "stake_mode",
+                description: "Stake MODE tokens for voting power. Returns NFT token ID",
+                parameters: stakeParametersSchema,
+            },
+            async (parameters: z.infer<typeof stakeParametersSchema>) => {
+                // First approve tokens
+                const approveHash = await walletClient.sendTransaction({
+                    to: MODE_CONTRACTS.MODE_TOKEN,
+                    abi: MODE_TOKEN_ABI,
+                    functionName: "approve",
+                    args: [MODE_CONTRACTS.VOTING_ESCROW, BigInt(parameters.amount)],
+                });
+
+                // Wait for approval
+                await walletClient.waitForTransactionReceipt({ hash: approveHash.hash });
+
+                // Calculate unlock time (current time + weeks)
+                const unlockTime = Math.floor(Date.now() / 1000) + parameters.lockDuration * 7 * 24 * 60 * 60;
+
+                // Create lock
+                const stakeHash = await walletClient.sendTransaction({
+                    to: MODE_CONTRACTS.VOTING_ESCROW,
+                    abi: VOTING_ESCROW_ABI,
+                    functionName: "create_lock",
+                    args: [BigInt(parameters.amount), BigInt(unlockTime)],
+                });
+
+                return stakeHash.hash;
+            }
+        ),
+
+        // Get staking positions
+        createTool(
+            {
+                name: "get_staking_positions",
+                description: "Get all staking positions for a wallet",
+                parameters: getStakingPositionsParametersSchema,
+            },
+            async (parameters: z.infer<typeof getStakingPositionsParametersSchema>) => {
+                const address = parameters.walletAddress || await walletClient.getAddress();
+
+                // Get number of NFTs
+                const balance = await walletClient.read({
+                    address: MODE_CONTRACTS.VENFT_LOCK,
+                    abi: VENFT_LOCK_ABI,
+                    functionName: "balanceOf",
+                    args: [address],
+                });
+
+                const positions = [];
+                const nftCount = Number(balance.value);
+
+                // Get all positions
+                for (let i = 0; i < nftCount; i++) {
+                    const tokenId = await walletClient.read({
+                        address: MODE_CONTRACTS.VENFT_LOCK,
+                        abi: VENFT_LOCK_ABI,
+                        functionName: "tokenOfOwnerByIndex",
+                        args: [address, BigInt(i)],
+                    });
+
+                    const locked = await walletClient.read({
+                        address: MODE_CONTRACTS.VOTING_ESCROW,
+                        abi: VOTING_ESCROW_ABI,
+                        functionName: "locked",
+                        args: [tokenId.value as bigint],
+                    });
+
+                    const votingPower = await walletClient.read({
+                        address: MODE_CONTRACTS.VOTING_ESCROW,
+                        abi: VOTING_ESCROW_ABI,
+                        functionName: "balanceOfNFT",
+                        args: [tokenId.value as bigint],
+                    });
+
+                    positions.push({
+                        tokenId: (tokenId.value as bigint).toString(),
+                        amount: (locked.value[0] as bigint).toString(),
+                        lockEnd: Number(locked.value[1]),
+                        votingPower: (votingPower.value as bigint).toString(),
+                    });
+                }
+
+                return positions;
+            }
+        ),
+
+        // Increase amount
+        createTool(
+            {
+                name: "increase_stake_amount",
+                description: "Increase the staked amount for an existing position",
+                parameters: increaseAmountParametersSchema,
+            },
+            async (parameters: z.infer<typeof increaseAmountParametersSchema>) => {
+                // Approve additional tokens
+                const approveHash = await walletClient.sendTransaction({
+                    to: MODE_CONTRACTS.MODE_TOKEN,
+                    abi: MODE_TOKEN_ABI,
+                    functionName: "approve",
+                    args: [MODE_CONTRACTS.VOTING_ESCROW, BigInt(parameters.additionalAmount)],
+                });
+
+                await walletClient.waitForTransactionReceipt({ hash: approveHash.hash });
+
+                // Increase amount
+                const hash = await walletClient.sendTransaction({
+                    to: MODE_CONTRACTS.VOTING_ESCROW,
+                    abi: VOTING_ESCROW_ABI,
+                    functionName: "increase_amount",
+                    args: [BigInt(parameters.tokenId), BigInt(parameters.additionalAmount)],
+                });
+
+                return hash.hash;
+            }
+        ),
+
+        // Increase lock time
+        createTool(
+            {
+                name: "increase_lock_time",
+                description: "Increase the lock time for an existing position",
+                parameters: increaseLockTimeParametersSchema,
+            },
+            async (parameters: z.infer<typeof increaseLockTimeParametersSchema>) => {
+                const newUnlockTime = Math.floor(Date.now() / 1000) + parameters.additionalWeeks * 7 * 24 * 60 * 60;
+
+                const hash = await walletClient.sendTransaction({
+                    to: MODE_CONTRACTS.VOTING_ESCROW,
+                    abi: VOTING_ESCROW_ABI,
+                    functionName: "increase_unlock_time",
+                    args: [BigInt(parameters.tokenId), BigInt(newUnlockTime)],
+                });
+
+                return hash.hash;
+            }
+        ),
+
+        // Get cooldown info
+        createTool(
+            {
+                name: "get_cooldown_info",
+                description: "Get cooldown information for a staking position",
+                parameters: getCooldownInfoParametersSchema,
+            },
+            async (parameters: z.infer<typeof getCooldownInfoParametersSchema>) => {
+                const cooldownEnd = await walletClient.read({
+                    address: MODE_CONTRACTS.EXIT_QUEUE,
+                    abi: EXIT_QUEUE_ABI,
+                    functionName: "cooldowns",
+                    args: [BigInt(parameters.tokenId)],
+                });
+
+                const currentTime = Math.floor(Date.now() / 1000);
+                const endTime = Number(cooldownEnd.value);
+
+                return {
+                    isInCooldown: endTime > currentTime,
+                    cooldownEnd: endTime,
+                    remainingTime: Math.max(0, endTime - currentTime),
+                };
+            }
+        ),
+
+        // Get warmup info
+        createTool(
+            {
+                name: "get_warmup_info",
+                description: "Get warmup information for a staking position",
+                parameters: getWarmupInfoParametersSchema,
+            },
+            async (parameters: z.infer<typeof getWarmupInfoParametersSchema>) => {
+                const warmupEnd = await walletClient.read({
+                    address: MODE_CONTRACTS.EXIT_QUEUE,
+                    abi: EXIT_QUEUE_ABI,
+                    functionName: "warmups",
+                    args: [BigInt(parameters.tokenId)],
+                });
+
+                const currentTime = Math.floor(Date.now() / 1000);
+                const endTime = Number(warmupEnd.value);
+
+                return {
+                    isInWarmup: endTime > currentTime,
+                    warmupEnd: endTime,
+                    remainingTime: Math.max(0, endTime - currentTime),
+                };
+            }
+        ),
+
+        // Unstake
+        createTool(
+            {
+                name: "unstake_mode",
+                description: "Unstake MODE tokens from a position",
+                parameters: unstakeParametersSchema,
+            },
+            async (parameters: z.infer<typeof unstakeParametersSchema>) => {
+                const hash = await walletClient.sendTransaction({
+                    to: MODE_CONTRACTS.VOTING_ESCROW,
+                    abi: VOTING_ESCROW_ABI,
+                    functionName: "withdraw",
+                    args: [BigInt(parameters.tokenId)],
+                });
+
+                return hash.hash;
+            }
+        ),
+    ];
+}

--- a/typescript/packages/plugins/mode-staking/src/parameters.ts
+++ b/typescript/packages/plugins/mode-staking/src/parameters.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const stakeParametersSchema = z.object({
+    amount: z.string().describe("Amount of MODE tokens to stake"),
+    lockDuration: z.number().describe("Lock duration in weeks (max 52)"),
+});
+
+export const unstakeParametersSchema = z.object({
+    tokenId: z.string().describe("NFT token ID representing the staking position"),
+});
+
+export const increaseAmountParametersSchema = z.object({
+    tokenId: z.string().describe("NFT token ID representing the staking position"),
+    additionalAmount: z.string().describe("Additional amount of MODE tokens to stake"),
+});
+
+export const increaseLockTimeParametersSchema = z.object({
+    tokenId: z.string().describe("NFT token ID representing the staking position"),
+    additionalWeeks: z.number().describe("Additional weeks to lock (total max 52)"),
+});
+
+export const getStakingPositionParametersSchema = z.object({
+    tokenId: z.string().describe("NFT token ID to query"),
+});
+
+export const getStakingPositionsParametersSchema = z.object({
+    walletAddress: z.string().optional().describe("Wallet address to query positions for (defaults to connected wallet)"),
+});
+
+export const getCooldownInfoParametersSchema = z.object({
+    tokenId: z.string().describe("NFT token ID to check cooldown for"),
+});
+
+export const getWarmupInfoParametersSchema = z.object({
+    tokenId: z.string().describe("NFT token ID to check warmup for"),
+});

--- a/typescript/packages/plugins/mode-staking/src/types/index.ts
+++ b/typescript/packages/plugins/mode-staking/src/types/index.ts
@@ -1,0 +1,28 @@
+export const MODE_CONTRACTS = {
+    MODE_TOKEN: "0xDfc7C877a950e49D2610114102175A06C2e3167a" as const,
+    VOTING_ESCROW: "0xff8AB822b8A853b01F9a9E9465321d6Fe77c9D2F" as const,
+    VENFT_LOCK: "0x06ab1Dc3c330E9CeA4fDF0C7C6F6Fb6442A4273C" as const,
+    EXIT_QUEUE: "0x915e50A7C53e05F72122bC883309a812A90bA163" as const,
+    CLOCK: "0x66CC481755f8a9d415e75d29C17B0E3eF2Af70bD" as const,
+} as const;
+
+export const MODE_CHAIN_ID = 34443;
+
+export type StakingPosition = {
+    tokenId: string;
+    amount: string;
+    lockEnd: number;
+    votingPower: string;
+};
+
+export type CooldownInfo = {
+    isInCooldown: boolean;
+    cooldownEnd: number;
+    remainingTime: number;
+};
+
+export type WarmupInfo = {
+    isInWarmup: boolean;
+    warmupEnd: number;
+    remainingTime: number;
+};

--- a/typescript/packages/plugins/mode-staking/tsconfig.json
+++ b/typescript/packages/plugins/mode-staking/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../../tsconfig.base.json",
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/plugins/mode-staking/tsup.config.ts
+++ b/typescript/packages/plugins/mode-staking/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { treeShakableConfig } from "../../../tsup.config.base";
+
+export default defineConfig({
+    ...treeShakableConfig,
+});

--- a/typescript/packages/plugins/mode-staking/turbo.json
+++ b/typescript/packages/plugins/mode-staking/turbo.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "extends": ["//"],
+    "tasks": {
+        "build": {
+            "inputs": ["src/**", "tsup.config.ts", "!./**/*.test.{ts,tsx}", "tsconfig.json"],
+            "dependsOn": ["^build"],
+            "outputs": ["dist/**"]
+        }
+    }
+}


### PR DESCRIPTION
# Relates to:
- Add Mode Staking Plugin 
- Add Mode Staking Plugin Examples

# Background
## What does this PR do?
This PR adds  the Mode Staking plugin and examples that demonstrate how to:

1. Create and manage staking positions in the Mode DAO
2. Interact with the staking contracts using GPT-4 and GOAT tools
3. Track cooldown/warmup periods for staking positions
4. Handle stake amounts and lock durations
5. Query staking positions and voting power

The examples follow the established project structure as seen in other examples like Coingecko.

## What kind of change is this?
- New feature (Mode Staking examples)
-  Documentation
-  Example code

# Documentation changes needed?
My changes include all necessary documentation:
- Comprehensive README with setup instructions
- Example usage documentation
- Clear code comments explaining functionality
- Added examples section in Mode Staking plugin docs

# Testing
## Detailed testing steps
1. Environment Setup:
   - Clone repository
   - Copy `.env.template` to `.env`
   - Configure MODE wallet and RPC provider

2. Installation:
   ```bash
   cd examples/vercel-ai/mode-staking
   npm install
   ```

3. Test Scenarios:
   - Run `npm start` to execute example tasks:
     - Verify successful connection to Mode Network
     - Check staking position queries work
     - Validate stake amount calculations
     - Test lock duration extensions
     - Confirm cooldown period tracking

4. GPT-4 Integration:
   - Verify AI responses are appropriate for each task
   - Confirm transaction suggestions are correct
   - Check error handling works as expected

## For plugins
- [x] I have tested this change locally with key pair wallets
- [x] I have tested this change locally with hosted wallets (Crossmint Smart Wallets)

## Telegram username
codingsh

