### PR TITLE
Re-export zod from the core package

### DIFF
--- a/typescript/packages/core/src/index.ts
+++ b/typescript/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from "./classes";
 export * from "./decorators";
 export * from "./types";
 export * from "./utils";
+export * from "zod";


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

https://discord.com/channels/1311079615732777010/1319833599003988049

# Background

When trying to create plugins externally typescript only allows the use of the zod package exported from the core package. I don't know why type inference doesn't work but that seems to be the only solution which allows users to create plugins without having to perpetually open PRs whenever they need to update their plugin or add another.

## What does this PR do?

This PR re-exports zod from the core package 

## What kind of change is this?

A one liner

# Documentation changes needed?

Yes, just add the zod importation source to the plugin docs

# Testing

## Detailed testing steps

None, automated tests are fine.

## For plugins
- [ ] I have tested this change locally with key pair wallets
- [ ] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)

## Discord username
shogun2077