### PR TITLE
Update WhirlpoolsConfig address

### DIFF
--- a/typescript/packages/plugins/orca/src/orca.service.ts
+++ b/typescript/packages/plugins/orca/src/orca.service.ts
@@ -5,6 +5,7 @@ import { Percentage, TransactionBuilder, resolveOrCreateATAs } from "@orca-so/co
 import {
     IncreaseLiquidityQuoteParam,
     NO_TOKEN_EXTENSION_CONTEXT,
+    ORCA_WHIRLPOOLS_CONFIG,
     ORCA_WHIRLPOOL_PROGRAM_ID,
     PDAUtil,
     PoolUtil,
@@ -12,7 +13,6 @@ import {
     TickUtil,
     TokenExtensionContextForPool,
     TokenExtensionUtil,
-    ORCA_WHIRLPOOLS_CONFIG,
     WhirlpoolContext,
     WhirlpoolIx,
     increaseLiquidityQuoteByInputTokenWithParams,

--- a/typescript/packages/plugins/orca/src/orca.service.ts
+++ b/typescript/packages/plugins/orca/src/orca.service.ts
@@ -12,7 +12,7 @@ import {
     TickUtil,
     TokenExtensionContextForPool,
     TokenExtensionUtil,
-    //   ORCA_WHIRLPOOLS_CONFIG,
+    ORCA_WHIRLPOOLS_CONFIG,
     WhirlpoolContext,
     WhirlpoolIx,
     increaseLiquidityQuoteByInputTokenWithParams,
@@ -39,8 +39,6 @@ export const FEE_TIERS = {
     1.0: 128,
     2.0: 256,
 } as const;
-
-const ORCA_WHIRLPOOLS_CONFIG = new PublicKey("FcrweFY1G9HJAHG5inkGB6pKg1HZ6x9UC2WioAfWrGkR");
 
 export class OrcaService {
     @Tool({


### PR DESCRIPTION
# Background

## What does this PR do?
Previously, the code was set to work with the Whirlpool Program on Devnet by having the WhirlpoolsConfig address set to the one on Devnet. This fix updates the WhirlpoolsConfig address to the one on Mainnet. For more information about WhirlpoolsConfig:
👉 [doc on Account Architecture](https://orca-so.github.io/whirlpools/Architecture%20Overview/Account%20Architecture#whirlpoolsconfig)
👉 [doc on Whirlpool Parameters](https://orca-so.github.io/whirlpools/Architecture%20Overview/Whirlpool%20Parameters)

## What kind of change is this?
Fix

# Documentation changes needed?
My changes require no change to the project documentation.

## For plugins
- [x] I have tested this change locally with key pair wallets
- [ ] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)

## Discord username
@calintje 