### PR TITLE
[Wallet] EVMWallets can take an arbitrary 'data' param now

### DIFF
--- a/typescript/packages/wallets/evm/src/types/EVMTransaction.ts
+++ b/typescript/packages/wallets/evm/src/types/EVMTransaction.ts
@@ -7,6 +7,7 @@ export type EVMTransaction = {
     value?: bigint;
     abi?: Abi;
     options?: EVMTransactionOptions;
+    data?: `0x${string}`;
 };
 
 export type EVMTransactionOptions = {


### PR DESCRIPTION
# Background

## What does this PR do?

Adds a data parameter to EVM transaction. Some tools need it as they require for some encoded data to eb sent alognside the tx

## What kind of change is this?

A wallet plug in change

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Detailed testing steps
None, automated tests are fine as this is an optional param


## For plugins
- [x] I have tested this change locally with key pair wallets
- [NO] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.) - filing a task for this

## Discord username
alfongj