### PR TITLE
Update send transaction and orca tool

### DIFF
--- a/typescript/packages/plugins/orca/src/orca.service.ts
+++ b/typescript/packages/plugins/orca/src/orca.service.ts
@@ -44,14 +44,14 @@ export class OrcaService {
         description:
             "Create a single-sided liquidity pool on the Orca DEX. This function initializes a new pool with liquidity contributed from a single token, allowing users to define an initial price, a maximum price, and other parameters. The function ensures proper mint order and on-chain configuration for seamless execution. Ideal for setting up a pool with minimal price impact, it supports advanced features like adjustable fee tiers and precise initial price settings.",
     })
-        async createSingleSidedPool(walletClient: SolanaWalletClient, parameters: CreateSingleSidedPoolParameters) {
+    async createSingleSidedPool(walletClient: SolanaWalletClient, parameters: CreateSingleSidedPoolParameters) {
         let whirlpoolsConfigAddress: PublicKey;
-        if (walletClient.getConnection().rpcEndpoint.includes('mainnet')) {
-            whirlpoolsConfigAddress = new PublicKey('2LecshUwdy9xi7meFgHtFJQNSKk4KdTrcpvaB56dP2NQ');
-        } else if (walletClient.getConnection().rpcEndpoint.includes('devnet')) {
-            whirlpoolsConfigAddress = new PublicKey('FcrweFY1G9HJAHG5inkGB6pKg1HZ6x9UC2WioAfWrGkR');
+        if (walletClient.getConnection().rpcEndpoint.includes("mainnet")) {
+            whirlpoolsConfigAddress = new PublicKey("2LecshUwdy9xi7meFgHtFJQNSKk4KdTrcpvaB56dP2NQ");
+        } else if (walletClient.getConnection().rpcEndpoint.includes("devnet")) {
+            whirlpoolsConfigAddress = new PublicKey("FcrweFY1G9HJAHG5inkGB6pKg1HZ6x9UC2WioAfWrGkR");
         } else {
-            throw new Error('Unsupported network');
+            throw new Error("Unsupported network");
         }
         const vanityWallet = new Wallet(new Keypair());
         const ctx = WhirlpoolContext.from(walletClient.getConnection(), vanityWallet, ORCA_WHIRLPOOL_PROGRAM_ID);
@@ -88,7 +88,11 @@ export class OrcaService {
             tokenMintWithProgramA: mintAAccount,
             tokenMintWithProgramB: mintBAccount,
         };
-        const feeTierKey = PDAUtil.getFeeTier(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolsConfigAddress, tickSpacing).publicKey;
+        const feeTierKey = PDAUtil.getFeeTier(
+            ORCA_WHIRLPOOL_PROGRAM_ID,
+            whirlpoolsConfigAddress,
+            tickSpacing,
+        ).publicKey;
         const initSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(initialTick);
         const tokenVaultAKeypair = Keypair.generate();
         const tokenVaultBKeypair = Keypair.generate();
@@ -280,7 +284,8 @@ export class OrcaService {
 
         const txPayload = await txBuilder.build();
         const instructions = TransactionMessage.decompile(
-            (txPayload.transaction as VersionedTransaction).message).instructions
+            (txPayload.transaction as VersionedTransaction).message,
+        ).instructions;
 
         try {
             const { hash } = await walletClient.sendTransaction({

--- a/typescript/packages/plugins/orca/src/orca.service.ts
+++ b/typescript/packages/plugins/orca/src/orca.service.ts
@@ -5,7 +5,6 @@ import { Percentage, TransactionBuilder, resolveOrCreateATAs } from "@orca-so/co
 import {
     IncreaseLiquidityQuoteParam,
     NO_TOKEN_EXTENSION_CONTEXT,
-    ORCA_WHIRLPOOLS_CONFIG,
     ORCA_WHIRLPOOL_PROGRAM_ID,
     PDAUtil,
     PoolUtil,
@@ -24,7 +23,7 @@ import {
     openPositionWithTokenExtensionsIx,
 } from "@orca-so/whirlpools-sdk/dist/instructions";
 import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
-import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { Keypair, PublicKey, Transaction, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
 import { Decimal } from "decimal.js";
 import { CreateSingleSidedPoolParameters } from "./parameters";
 
@@ -45,7 +44,15 @@ export class OrcaService {
         description:
             "Create a single-sided liquidity pool on the Orca DEX. This function initializes a new pool with liquidity contributed from a single token, allowing users to define an initial price, a maximum price, and other parameters. The function ensures proper mint order and on-chain configuration for seamless execution. Ideal for setting up a pool with minimal price impact, it supports advanced features like adjustable fee tiers and precise initial price settings.",
     })
-    async createSingleSidedPool(walletClient: SolanaWalletClient, parameters: CreateSingleSidedPoolParameters) {
+        async createSingleSidedPool(walletClient: SolanaWalletClient, parameters: CreateSingleSidedPoolParameters) {
+        let whirlpoolsConfigAddress: PublicKey;
+        if (walletClient.getConnection().rpcEndpoint.includes('mainnet')) {
+            whirlpoolsConfigAddress = new PublicKey('2LecshUwdy9xi7meFgHtFJQNSKk4KdTrcpvaB56dP2NQ');
+        } else if (walletClient.getConnection().rpcEndpoint.includes('devnet')) {
+            whirlpoolsConfigAddress = new PublicKey('FcrweFY1G9HJAHG5inkGB6pKg1HZ6x9UC2WioAfWrGkR');
+        } else {
+            throw new Error('Unsupported network');
+        }
         const vanityWallet = new Wallet(new Keypair());
         const ctx = WhirlpoolContext.from(walletClient.getConnection(), vanityWallet, ORCA_WHIRLPOOL_PROGRAM_ID);
         const fetcher = ctx.fetcher;
@@ -81,22 +88,22 @@ export class OrcaService {
             tokenMintWithProgramA: mintAAccount,
             tokenMintWithProgramB: mintBAccount,
         };
-        const feeTierKey = PDAUtil.getFeeTier(ORCA_WHIRLPOOL_PROGRAM_ID, ORCA_WHIRLPOOLS_CONFIG, tickSpacing).publicKey;
+        const feeTierKey = PDAUtil.getFeeTier(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolsConfigAddress, tickSpacing).publicKey;
         const initSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(initialTick);
         const tokenVaultAKeypair = Keypair.generate();
         const tokenVaultBKeypair = Keypair.generate();
         const whirlpoolPda = PDAUtil.getWhirlpool(
             ORCA_WHIRLPOOL_PROGRAM_ID,
-            ORCA_WHIRLPOOLS_CONFIG,
+            whirlpoolsConfigAddress,
             mintA,
             mintB,
             FEE_TIERS[feeTier],
         );
-        const tokenBadgeA = PDAUtil.getTokenBadge(ORCA_WHIRLPOOL_PROGRAM_ID, ORCA_WHIRLPOOLS_CONFIG, mintA).publicKey;
-        const tokenBadgeB = PDAUtil.getTokenBadge(ORCA_WHIRLPOOL_PROGRAM_ID, ORCA_WHIRLPOOLS_CONFIG, mintB).publicKey;
+        const tokenBadgeA = PDAUtil.getTokenBadge(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolsConfigAddress, mintA).publicKey;
+        const tokenBadgeB = PDAUtil.getTokenBadge(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolsConfigAddress, mintB).publicKey;
         const baseParamsPool = {
             initSqrtPrice,
-            whirlpoolsConfig: ORCA_WHIRLPOOLS_CONFIG,
+            whirlpoolsConfig: whirlpoolsConfigAddress,
             whirlpoolPda,
             tokenMintA: mintA,
             tokenMintB: mintB,
@@ -202,7 +209,7 @@ export class OrcaService {
             walletAddress,
             undefined,
             ctx.accountResolverOpts.allowPDAOwnerAddress,
-            ctx.accountResolverOpts.createWrappedSolAccountMethod,
+            "ata",
         );
         const { address: tokenOwnerAccountA, ...tokenOwnerAccountAIx } = ataA;
         const { address: tokenOwnerAccountB, ...tokenOwnerAccountBIx } = ataB;
@@ -271,20 +278,18 @@ export class OrcaService {
               });
         txBuilder.addInstruction(liquidityIx);
 
-        const txPayload = await txBuilder.build({
-            maxSupportedTransactionVersion: "legacy",
-        });
+        const txPayload = await txBuilder.build();
+        const instructions = TransactionMessage.decompile(
+            (txPayload.transaction as VersionedTransaction).message).instructions
 
-        if (txPayload.transaction instanceof Transaction) {
-            try {
-                const { hash } = await walletClient.sendTransaction({
-                    instructions: txPayload.transaction.instructions,
-                    accountsToSign: [positionMintKeypair, tokenVaultAKeypair, tokenVaultBKeypair],
-                });
-                return hash;
-            } catch (error) {
-                throw new Error(`Failed to create pool: ${JSON.stringify(error)}`);
-            }
+        try {
+            const { hash } = await walletClient.sendTransaction({
+                instructions: instructions,
+                accountsToSign: [positionMintKeypair, tokenVaultAKeypair, tokenVaultBKeypair],
+            });
+            return hash;
+        } catch (error) {
+            throw new Error(`Failed to create pool: ${JSON.stringify(error)}`);
         }
     }
 }

--- a/typescript/packages/wallets/solana/src/SolanaKeypairWalletClient.ts
+++ b/typescript/packages/wallets/solana/src/SolanaKeypairWalletClient.ts
@@ -1,4 +1,4 @@
-import { type Keypair, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+import { ComputeBudgetProgram, type Keypair, PublicKey, TransactionInstruction, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
 import nacl from "tweetnacl";
 import { type SolanWalletClientCtorParams, SolanaWalletClient } from "./SolanaWalletClient";
 import type { SolanaTransaction } from "./types";
@@ -28,35 +28,98 @@ export class SolanaKeypairWalletClient extends SolanaWalletClient {
         };
     }
 
-    async sendTransaction({ instructions, addressLookupTableAddresses = [], accountsToSign = [] }: SolanaTransaction) {
-        const latestBlockhash = await this.connection.getLatestBlockhash();
-
-        const message = new TransactionMessage({
+    async sendTransaction({ instructions, addressLookupTableAddresses = [], accountsToSign = [] }: SolanaTransaction): Promise<{ hash: string }> {
+        const ixComputeBudget = await this.getComputeBudgetInstructions(instructions, "mid");
+        const allInstructions = [
+            ixComputeBudget.computeBudgetLimitInstruction,
+            ixComputeBudget.computeBudgetPriorityFeeInstructions,
+            ...instructions];
+        const messageV0 = new TransactionMessage({
             payerKey: this.#keypair.publicKey,
-            recentBlockhash: latestBlockhash.blockhash,
-            instructions,
+            recentBlockhash: ixComputeBudget.blockhash,
+            instructions: allInstructions,
         }).compileToV0Message(await this.getAddressLookupTableAccounts(addressLookupTableAddresses));
-        const transaction = new VersionedTransaction(message);
-
+        const transaction = new VersionedTransaction(messageV0);
         transaction.sign([this.#keypair, ...accountsToSign]);
 
-        const hash = await this.connection.sendTransaction(transaction, {
-            maxRetries: 10,
-            preflightCommitment: "confirmed",
-        });
+        const timeoutMs = 90000;
+        const startTime = Date.now();
+        while (Date.now() - startTime < timeoutMs) {
+            const transactionStartTime = Date.now();
 
-        await this.connection.confirmTransaction(
-            {
-                blockhash: latestBlockhash.blockhash,
-                lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
-                signature: hash,
-            },
-            "confirmed",
-        );
+            const hash = await this.connection.sendTransaction(
+                transaction,
+                {
+                    maxRetries: 0,
+                    skipPreflight: true,
+                });
 
-        return {
-            hash,
-        };
+            const statuses = await this.connection.getSignatureStatuses([hash]);
+            if (statuses.value[0]) {
+                if (!statuses.value[0].err) {
+                    return { hash };
+                } else {
+                    throw new Error(`Transaction failed: ${statuses.value[0].err.toString()}`);
+                }
+            }
+
+            const elapsedTime = Date.now() - transactionStartTime;
+            const remainingTime = Math.max(0, 1000 - elapsedTime);
+            if (remainingTime > 0) {
+                await new Promise(resolve => setTimeout(resolve, remainingTime));
+            }
+        }
+        throw new Error("Transaction timeout");
+    }
+
+    private priorityFeeTiers = {
+        min: 0.01,
+        mid: 0.5,
+        max: 0.95
+    };
+
+    private async getComputeBudgetInstructions(instructions: TransactionInstruction[], feeTier: keyof typeof this.priorityFeeTiers): Promise<{
+        blockhash: string;
+        computeBudgetLimitInstruction: TransactionInstruction;
+        computeBudgetPriorityFeeInstructions: TransactionInstruction;
+    }> {
+        try {
+            const blockhash = (await this.connection.getLatestBlockhash()).blockhash;
+            const messageV0 = new TransactionMessage({
+                payerKey: this.#keypair.publicKey,
+                recentBlockhash: blockhash,
+                instructions: instructions,
+            }).compileToV0Message();
+            const transaction = new VersionedTransaction(messageV0);
+            const simulatedTx = this.connection.simulateTransaction(transaction);
+            const estimatedComputeUnits = (await simulatedTx).value.unitsConsumed;
+            const safeComputeUnits = Math.ceil(
+                estimatedComputeUnits ?
+                    Math.max(estimatedComputeUnits + 100000, estimatedComputeUnits * 1.2)
+                    : 200000
+            );
+            const computeBudgetLimitInstruction = ComputeBudgetProgram.setComputeUnitLimit({
+                units: safeComputeUnits,
+            });
+
+            const priorityFee = await this.connection.getRecentPrioritizationFees()
+                .then(fees =>
+                    fees.sort((a, b) => a.prioritizationFee - b.prioritizationFee)
+                    [Math.floor(fees.length * this.priorityFeeTiers[feeTier])].prioritizationFee
+                );
+
+            const computeBudgetPriorityFeeInstructions = ComputeBudgetProgram.setComputeUnitPrice({
+                microLamports: priorityFee,
+            });
+
+            return {
+                blockhash,
+                computeBudgetLimitInstruction,
+                computeBudgetPriorityFeeInstructions
+            };
+        } catch (error) {
+            throw new Error(`Failed to get compute budget instructions: ${error}`);
+        }
     }
 }
 

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -614,9 +614,6 @@ importers:
       '@goat-sdk/plugin-jupiter':
         specifier: workspace:*
         version: link:../../../packages/plugins/jupiter
-      '@goat-sdk/plugin-orca':
-        specifier: workspace:*
-        version: link:../../../packages/plugins/orca
       '@goat-sdk/plugin-spl-token':
         specifier: workspace:*
         version: link:../../../packages/plugins/spl-token

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       '@goat-sdk/plugin-jupiter':
         specifier: workspace:*
         version: link:../../../packages/plugins/jupiter
+      '@goat-sdk/plugin-orca':
+        specifier: workspace:*
+        version: link:../../../packages/plugins/orca
       '@goat-sdk/plugin-spl-token':
         specifier: workspace:*
         version: link:../../../packages/plugins/spl-token


### PR DESCRIPTION
# Background

## What does this PR do?

This PR adds the following 3 things:
- Single Sided pool creation can now be done on Devnet
- Changed the wrapping strategy for SOL to reduce transaction size in case the agent does not have WSOL account
- Update send transaction logic. I took the liberty to update the function to optimize it for transaction landing, which is especially important in DeFi operations, including:
  - Include computeBugetSetUnitLimit instruction
  - Replace the deprecated 'confirmTransaction' API method: https://solana.com/docs/rpc/deprecated/confirmtransaction
  - Client-side retry mechanism. https://www.helius.dev/blog/how-to-land-transactions-on-solana

## What kind of change is this?
Update/improvement

# Documentation changes needed?

My changes do not require a change to the project documentation.


# Testing

## Detailed testing steps
Used vercel-ai Solana example.

prompt: single sided pool on orca: deposit amount, 1000000000000000, deposit mint: A1tXcEZzUhhstyN4FFc4fQpNH4rLgTBZqVN5tsVow1Mf, other mint So11111111111111111111111111111111111111112, initial price 0.001, max price 1.0, fee tier 2.0

Transaction executed by the agent:
https://solscan.io/tx/3u59wSqNBGJqKJjN4n9vzhtx1w637wVDDhhsmBmtE1S8hgv1XRLPTbcrahot48Ya9YSZFcYqQHu3f9H87ssE8JNu?cluster=devnet

## For plugins
- [x] I have tested this change locally with key pair wallets
- [ ] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)

## Discord username
@calintje 