### PR TITLE
Add revoke approval tool for ERC20 plugin

### DIFF
--- a/typescript/packages/plugins/erc20/src/erc20.service.ts
+++ b/typescript/packages/plugins/erc20/src/erc20.service.ts
@@ -9,6 +9,7 @@ import {
     GetTokenBalanceParameters,
     GetTokenInfoBySymbolParameters,
     GetTokenTotalSupplyParameters,
+    RevokeApprovalParameters,
     TransferFromParameters,
     TransferParameters,
 } from "./parameters";
@@ -141,6 +142,25 @@ export class Erc20Service {
             return hash.hash;
         } catch (error) {
             throw Error(`Failed to approve: ${error}`);
+        }
+    }
+
+    @Tool({
+        description: "Revoke approval for an ERC20 token to an address",
+    })
+    async revokeApproval(walletClient: EVMWalletClient, parameters: RevokeApprovalParameters) {
+        try {
+            const spender = await walletClient.resolveAddress(parameters.spender);
+
+            const hash = await walletClient.sendTransaction({
+                to: parameters.tokenAddress,
+                abi: ERC20_ABI,
+                functionName: "approve",
+                args: [spender, 0],
+            });
+            return hash.hash;
+        } catch (error) {
+            throw Error(`Failed to revoke approval: ${error}`);
         }
     }
 

--- a/typescript/packages/plugins/erc20/src/parameters.ts
+++ b/typescript/packages/plugins/erc20/src/parameters.ts
@@ -44,6 +44,13 @@ export class ApproveParameters extends createToolParameters(
     }),
 ) {}
 
+export class RevokeApprovalParameters extends createToolParameters(
+    z.object({
+        tokenAddress: z.string().describe("The address of the token to revoke"),
+        spender: z.string().describe("The address to revoke the allowance to"),
+    }),
+) {}
+
 export class TransferFromParameters extends createToolParameters(
     z.object({
         tokenAddress: z.string().describe("The address of the token to transfer"),

--- a/typescript/packages/wallets/solana/src/SolanaKeypairWalletClient.ts
+++ b/typescript/packages/wallets/solana/src/SolanaKeypairWalletClient.ts
@@ -1,19 +1,11 @@
-import {
-    type Keypair,
-    TransactionMessage,
-    VersionedTransaction,
-} from "@solana/web3.js";
+import { type Keypair, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
 import nacl from "tweetnacl";
-import {
-    type SolanWalletClientCtorParams,
-    SolanaWalletClient,
-} from "./SolanaWalletClient";
+import { type SolanWalletClientCtorParams, SolanaWalletClient } from "./SolanaWalletClient";
 import type { SolanaTransaction } from "./types";
 
-export type SolanaKeypairWalletClientCtorParams =
-    SolanWalletClientCtorParams & {
-        keypair: Keypair;
-    };
+export type SolanaKeypairWalletClientCtorParams = SolanWalletClientCtorParams & {
+    keypair: Keypair;
+};
 
 export class SolanaKeypairWalletClient extends SolanaWalletClient {
     #keypair: Keypair;
@@ -30,31 +22,20 @@ export class SolanaKeypairWalletClient extends SolanaWalletClient {
 
     async signMessage(message: string) {
         const messageBytes = Buffer.from(message);
-        const signature = nacl.sign.detached(
-            messageBytes,
-            this.#keypair.secretKey
-        );
+        const signature = nacl.sign.detached(messageBytes, this.#keypair.secretKey);
         return {
             signature: Buffer.from(signature).toString("hex"),
         };
     }
 
-    async sendTransaction({
-        instructions,
-        addressLookupTableAddresses = [],
-        accountsToSign = [],
-    }: SolanaTransaction) {
+    async sendTransaction({ instructions, addressLookupTableAddresses = [], accountsToSign = [] }: SolanaTransaction) {
         const latestBlockhash = await this.connection.getLatestBlockhash();
 
         const message = new TransactionMessage({
             payerKey: this.#keypair.publicKey,
             recentBlockhash: latestBlockhash.blockhash,
             instructions,
-        }).compileToV0Message(
-            await this.getAddressLookupTableAccounts(
-                addressLookupTableAddresses
-            )
-        );
+        }).compileToV0Message(await this.getAddressLookupTableAccounts(addressLookupTableAddresses));
         const transaction = new VersionedTransaction(message);
 
         transaction.sign([this.#keypair, ...accountsToSign]);
@@ -70,7 +51,7 @@ export class SolanaKeypairWalletClient extends SolanaWalletClient {
                 lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
                 signature: hash,
             },
-            "confirmed"
+            "confirmed",
         );
 
         return {
@@ -79,5 +60,4 @@ export class SolanaKeypairWalletClient extends SolanaWalletClient {
     }
 }
 
-export const solana = (params: SolanaKeypairWalletClientCtorParams) =>
-    new SolanaKeypairWalletClient(params);
+export const solana = (params: SolanaKeypairWalletClientCtorParams) => new SolanaKeypairWalletClient(params);


### PR DESCRIPTION
# Background
While using the ERC20 plugin for a portfolio manager, I noticed that the following prompt does not work to revoke approvals for ERC20 tokens.
>Revoke approval for PEPE tokens to 0x9d85494061dFdf8ad40B3aB3A73E897CA5F4f27B

I think adding support for prompts like this this will be useful for many ERC20 plugin use-cases such as trading agents, portfolio managers, tipping bots etc. Adding this tool will allow users to easily revoke approvals using generic prompts such as the one I tried above.

## What does this PR do?
This PR adds a new tool to the ERC20 plugin: `revokeApproval`
 - Add new parameter `RevokeApprovalParameters` which contains only spender and token address
 - Use parameters in the `revokeApproval` action to set approval amount to 0 for the given spender and token address

# Testing
After adding the new tool, I used the following testing steps:
 1) Approve spending of 5000 PEPE tokens on Base to 0x9d85494061dFdf8ad40B3aB3A73E897CA5F4f27B
 2) Verified that the tokens are indeed approved
 3) Revoked approval of PEPE tokens on Base to 0x9d85494061dFdf8ad40B3aB3A73E897CA5F4f27B
 4) Verified that the token approval is indeed revoked

## Detailed testing results
### Approve
Used the `approve` tool to approve 5000 PEPE tokens for approval on Base to 0x9d85494061dFdf8ad40B3aB3A73E897CA5F4f27B.

Transaction hash: 0x838abcb75e30221686802c9832028caa528ffc5305c0affedebb31e62901f125

Screenshot from revoke.cash:
<img width="1236" alt="Screenshot 2024-12-30 at 5 22 39 PM" src="https://github.com/user-attachments/assets/9e0cb7b1-2d51-4c12-b086-de21ee3ba059" />

### Revoke
Used the newly added `revokeApproval` tool to revoke approval for PEPE tokens on Base to 0x9d85494061dFdf8ad40B3aB3A73E897CA5F4f27B.

Transaction hash: 0x0fcc7c1a5adb1decfa3a1f2523de31a8ba059c6904efd48937ddad2cce9405f7

Screenshot from revoke.cash:
<img width="1230" alt="Screenshot 2024-12-30 at 5 25 57 PM" src="https://github.com/user-attachments/assets/c09d3b67-adca-48ab-95fd-4b8757f056ae" />

Screenshot of response:
<img width="838" alt="Screenshot 2024-12-30 at 5 25 41 PM" src="https://github.com/user-attachments/assets/f946ad0e-93de-46cf-9b54-ebc514acbb80" />


## Discord username
`toozol1`