### PR TITLE
Add Chromia mainnet/testnet support and custom asset transfer functio…

### DIFF
--- a/typescript/examples/vercel-ai/chromia/.env.template
+++ b/typescript/examples/vercel-ai/chromia/.env.template
@@ -1,2 +1,3 @@
 OPENAI_API_KEY=
 EVM_PRIVATE_KEY=
+CHROMIA_NETWORK=  # 'mainnet' or 'testnet'

--- a/typescript/examples/vercel-ai/chromia/index.ts
+++ b/typescript/examples/vercel-ai/chromia/index.ts
@@ -3,7 +3,7 @@ import { openai } from "@ai-sdk/openai";
 import { createConnection, createInMemoryEvmKeyStore, createKeyStoreInteractor } from "@chromia/ft4";
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
 import { sendCHR } from "@goat-sdk/wallet-chromia";
-import { chromia, CHROMIA_CONFIG } from "@goat-sdk/wallet-chromia";
+import { CHROMIA_CONFIG, chromia } from "@goat-sdk/wallet-chromia";
 import { generateText } from "ai";
 import chalk from "chalk";
 import { type KeyPair, createClient } from "postchain-client";

--- a/typescript/examples/vercel-ai/chromia/index.ts
+++ b/typescript/examples/vercel-ai/chromia/index.ts
@@ -3,7 +3,7 @@ import { openai } from "@ai-sdk/openai";
 import { createConnection, createInMemoryEvmKeyStore, createKeyStoreInteractor } from "@chromia/ft4";
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
 import { sendCHR } from "@goat-sdk/wallet-chromia";
-import { CHROMIA_MAINNET_BRID, chromia } from "@goat-sdk/wallet-chromia";
+import { chromia, CHROMIA_CONFIG } from "@goat-sdk/wallet-chromia";
 import { generateText } from "ai";
 import chalk from "chalk";
 import { type KeyPair, createClient } from "postchain-client";
@@ -11,11 +11,18 @@ import { z } from "zod";
 import { MASTER_PROMPT, getLiveTokenPrice } from "./tools";
 require("dotenv").config();
 
+const chromiaNetwork = process.env.CHROMIA_NETWORK?.toLowerCase() as keyof typeof CHROMIA_CONFIG;
 const privateKey = process.env.EVM_PRIVATE_KEY;
+
+if (!chromiaNetwork || !(chromiaNetwork in CHROMIA_CONFIG)) {
+    throw new Error("CHROMIA_NETWORK must be set to 'mainnet' or 'testnet' in the environment.");
+}
 
 if (!privateKey) {
     throw new Error("EVM_PRIVATE_KEY is not set in the environment");
 }
+
+const config = CHROMIA_CONFIG[chromiaNetwork];
 
 async function chat(tools: object) {
     const rl = readline.createInterface({
@@ -86,8 +93,8 @@ async function chat(tools: object) {
 
 (async () => {
     const chromiaClient = await createClient({
-        nodeUrlPool: ["https://system.chromaway.com:7740"],
-        blockchainRid: CHROMIA_MAINNET_BRID.ECONOMY_CHAIN,
+        nodeUrlPool: config.NODE_URL_POOL,
+        blockchainRid: config.ECONOMY_CHAIN_BRID,
     });
     const connection = createConnection(chromiaClient);
     const evmKeyStore = createInMemoryEvmKeyStore({
@@ -103,6 +110,7 @@ async function chat(tools: object) {
             client: chromiaClient,
             accountAddress,
             keystoreInteractor,
+            assetId: config.CHR_ASSET_ID,
             connection,
         }),
         plugins: [sendCHR()],

--- a/typescript/packages/wallets/chromia/src/ChromiaWalletClient.ts
+++ b/typescript/packages/wallets/chromia/src/ChromiaWalletClient.ts
@@ -30,7 +30,7 @@ export class ChromiaWalletClient extends WalletClientBase {
 
         if (!network) {
             throw new Error(
-                `Unknown directoryChainRid: ${directoryChainRid}. Ensure the client is configured correctly.`
+                `Unknown directoryChainRid: ${directoryChainRid}. Ensure the client is configured correctly.`,
             );
         }
 
@@ -62,7 +62,7 @@ export class ChromiaWalletClient extends WalletClientBase {
         if (!asset) {
             throw new Error(`Asset ${assetId} not found on Blockchain RID: ${connection.blockchainRid}`);
         }
-       
+
         const amountToSend = createAmount(amount, asset.decimals);
         return await session.account.transfer(to, assetId, amountToSend);
     }

--- a/typescript/packages/wallets/chromia/src/ChromiaWalletClient.ts
+++ b/typescript/packages/wallets/chromia/src/ChromiaWalletClient.ts
@@ -2,19 +2,39 @@ import { type Connection, type KeyStoreInteractor, createAmount } from "@chromia
 import { WalletClientBase } from "@goat-sdk/core";
 import type { DictPair, IClient, QueryObject, RawGtv } from "postchain-client";
 import { formatUnits } from "viem";
-import { CHR_ASSET_ID } from "./consts";
+import { CHROMIA_CONFIG } from "./consts";
 import type { ChromiaTransaction } from "./types/ChromiaTransaction";
 
 export type ChromiaWalletCtorParams = {
     client: IClient;
     keystoreInteractor: KeyStoreInteractor;
     accountAddress: string;
+    assetId: string;
     connection: Connection;
 };
 
 export class ChromiaWalletClient extends WalletClientBase {
+    public readonly networkName: string; // Store "mainnet" or "testnet"
+
     constructor(public readonly params: ChromiaWalletCtorParams) {
         super();
+
+        // Mapping directoryChainRid to network names
+        const DIRECTORY_CHAIN_BRIDS: Record<string, string> = {
+            "7E5BE539EF62E48DDA7035867E67734A70833A69D2F162C457282C319AA58AE4": "mainnet",
+            "6F1B061C633A992BF195850BF5AA1B6F887AEE01BB3F51251C230930FB792A92": "testnet",
+        };
+
+        const directoryChainRid = params.client.config.directoryChainRid;
+        const network = DIRECTORY_CHAIN_BRIDS[directoryChainRid];
+
+        if (!network) {
+            throw new Error(
+                `Unknown directoryChainRid: ${directoryChainRid}. Ensure the client is configured correctly.`
+            );
+        }
+
+        this.networkName = network; // Save network name for use in explorer links
     }
 
     getAddress(): string {
@@ -30,18 +50,19 @@ export class ChromiaWalletClient extends WalletClientBase {
         return { signature: "" };
     }
 
-    async sendTransaction({ to, assetId, amount }: ChromiaTransaction) {
+    async sendTransaction({ to, amount }: ChromiaTransaction) {
         if (!to.match(/^[a-f0-9]{64}$/i)) {
             throw new Error("Invalid Address");
         }
 
-        const { keystoreInteractor, connection } = this.params;
+        const { keystoreInteractor, connection, assetId } = this.params;
         const accounts = await keystoreInteractor.getAccounts();
         const session = await keystoreInteractor.getSession(accounts[0].id);
         const asset = await connection.getAssetById(assetId);
         if (!asset) {
-            throw new Error("Asset not found");
+            throw new Error(`Asset ${assetId} not found on Blockchain RID: ${connection.blockchainRid}`);
         }
+       
         const amountToSend = createAmount(amount, asset.decimals);
         return await session.account.transfer(to, assetId, amountToSend);
     }
@@ -51,9 +72,10 @@ export class ChromiaWalletClient extends WalletClientBase {
     }
 
     async balanceOf(address: string) {
-        const account = await this.params.connection.getAccountById(address);
+        const { connection, assetId } = this.params;
+        const account = await connection.getAccountById(address);
         if (account) {
-            const balance = await account.getBalanceByAssetId(CHR_ASSET_ID);
+            const balance = await account.getBalanceByAssetId(assetId);
             if (balance) {
                 return {
                     decimals: balance.asset.decimals,
@@ -64,10 +86,16 @@ export class ChromiaWalletClient extends WalletClientBase {
                 };
             }
         }
+
+        const asset = await connection.getAssetById(assetId);
+        if (!asset) {
+            throw new Error(`Asset ${assetId} not found on Blockchain RID: ${connection.blockchainRid}`);
+        }
+
         return {
-            decimals: 0,
-            symbol: "CHR",
-            name: "Chromia",
+            decimals: asset.decimals,
+            symbol: asset.symbol,
+            name: asset.name,
             value: "0",
             inBaseUnits: "0",
         };

--- a/typescript/packages/wallets/chromia/src/consts.ts
+++ b/typescript/packages/wallets/chromia/src/consts.ts
@@ -1,5 +1,35 @@
-export enum CHROMIA_MAINNET_BRID {
-    ECONOMY_CHAIN = "15C0CA99BEE60A3B23829968771C50E491BD00D2E3AE448580CD48A8D71E7BBA",
-}
-
-export const CHR_ASSET_ID = "5f16d1545a0881f971b164f1601cbbf51c29efd0633b2730da18c403c3b428b5";
+export const CHROMIA_CONFIG = {
+    mainnet: {
+        NETWORK: "mainnet",
+        ECONOMY_CHAIN_BRID: "15C0CA99BEE60A3B23829968771C50E491BD00D2E3AE448580CD48A8D71E7BBA",
+        CHR_ASSET_ID: "5f16d1545a0881f971b164f1601cbbf51c29efd0633b2730da18c403c3b428b5",
+        NODE_URL_POOL: [
+            "https://system.chromaway.com:7740",
+            "https://chromia.mainnet.validatrium.club:7740",
+            "https://chromia-mainnet-systemnode-1.stakin-nodes.com:7740",
+            "https://chroma.node.monster:7741",
+            "https://chromia.mainnet-system.nodeops.ninja:7740",
+            "https://chromia-mainnet-1.dappradar.com:7740",
+            "https://sys-main.chromia.coinhall.org:7740",
+            "https://chromia-mainnet.everstake.one:7740",
+            "https://chromia-mainnet.stakewith.us:7740",
+            "https://chromia-sp.bwarelabs.com:7740",
+            "https://chromia-api.hashkey.cloud:7740",
+            "https://chromia-mainnet-system-node.asymm.ventures:7740",
+            "https://chr.bbbnnnbbb.net:443",
+            "https://chromia-system-node.moca-services.xyz:7740",
+            "https://chromia-mainnet-system.dwellir.com:443"
+        ],
+    },
+    testnet: {
+        NETWORK: "testnet",
+        ECONOMY_CHAIN_BRID: "090BCD47149FBB66F02489372E88A454E7A5645ADDE82125D40DF1EF0C76F874",
+        CHR_ASSET_ID: "9EF73A786A66F435B3B40E72F5E9D85A4B09815997E087C809913E1E7EC686B4",
+        NODE_URL_POOL: [
+            "https://node0.testnet.chromia.com:7740",
+            "https://node1.testnet.chromia.com:7740",
+            "https://node2.testnet.chromia.com:7740",
+            "https://node3.testnet.chromia.com:7740"
+        ],
+    },
+};

--- a/typescript/packages/wallets/chromia/src/consts.ts
+++ b/typescript/packages/wallets/chromia/src/consts.ts
@@ -18,7 +18,7 @@ export const CHROMIA_CONFIG = {
             "https://chromia-mainnet-system-node.asymm.ventures:7740",
             "https://chr.bbbnnnbbb.net:443",
             "https://chromia-system-node.moca-services.xyz:7740",
-            "https://chromia-mainnet-system.dwellir.com:443"
+            "https://chromia-mainnet-system.dwellir.com:443",
         ],
     },
     testnet: {
@@ -29,7 +29,7 @@ export const CHROMIA_CONFIG = {
             "https://node0.testnet.chromia.com:7740",
             "https://node1.testnet.chromia.com:7740",
             "https://node2.testnet.chromia.com:7740",
-            "https://node3.testnet.chromia.com:7740"
+            "https://node3.testnet.chromia.com:7740",
         ],
     },
 };

--- a/typescript/packages/wallets/chromia/src/sendCHR.plugin.ts
+++ b/typescript/packages/wallets/chromia/src/sendCHR.plugin.ts
@@ -2,8 +2,6 @@ import { Chain, PluginBase } from "@goat-sdk/core";
 import { createTool } from "@goat-sdk/core";
 import { z } from "zod";
 import { ChromiaWalletClient } from "./ChromiaWalletClient";
-import { CHROMIA_MAINNET_BRID } from "./consts";
-import { CHR_ASSET_ID } from "./consts";
 
 export class SendCHRPlugin extends PluginBase<ChromiaWalletClient> {
     constructor() {
@@ -18,7 +16,7 @@ export class SendCHRPlugin extends PluginBase<ChromiaWalletClient> {
         const sendTool = createTool(
             {
                 name: "send_CHR",
-                description: "Send CHR to an address.",
+                description: "Send a Chromia asset to an address",
                 parameters: sendCHRParametersSchema,
             },
             (parameters: z.infer<typeof sendCHRParametersSchema>) => sendCHRMethod(walletClient, parameters),
@@ -30,8 +28,8 @@ export class SendCHRPlugin extends PluginBase<ChromiaWalletClient> {
 export const sendCHR = () => new SendCHRPlugin();
 
 const sendCHRParametersSchema = z.object({
-    to: z.string().describe("The address to send CHR to"),
-    amount: z.string().describe("The amount of CHR to send"),
+    to: z.string().describe("The address to send the Chromia asset to"),
+    amount: z.string().describe("The amount of the Chromia asset to send"),
 });
 
 async function sendCHRMethod(
@@ -40,15 +38,18 @@ async function sendCHRMethod(
 ): Promise<string> {
     try {
         const { to, amount } = parameters;
+        const { assetId, connection } = walletClient.params;
         const { receipt } = await walletClient.sendTransaction({
             to,
-            assetId: CHR_ASSET_ID,
+            assetId,
             amount,
         });
-        return `https://explorer.chromia.com/mainnet/${
-            CHROMIA_MAINNET_BRID.ECONOMY_CHAIN
+    
+        return `https://explorer.chromia.com/${walletClient.networkName}/${
+            connection.blockchainRid.toString("hex")
         }/transaction/${receipt.transactionRid.toString("hex")}`;
     } catch (error) {
-        return `Error sending CHR: ${error}`;
-    }
+        console.error("Debug - Error Details:", error);
+        return `Error sending the Chromia asset. Ensure the recipient address, asset ID, and amount are correct. Details: ${error}`;
+    }    
 }

--- a/typescript/packages/wallets/chromia/src/sendCHR.plugin.ts
+++ b/typescript/packages/wallets/chromia/src/sendCHR.plugin.ts
@@ -44,12 +44,12 @@ async function sendCHRMethod(
             assetId,
             amount,
         });
-    
-        return `https://explorer.chromia.com/${walletClient.networkName}/${
-            connection.blockchainRid.toString("hex")
-        }/transaction/${receipt.transactionRid.toString("hex")}`;
+
+        return `https://explorer.chromia.com/${walletClient.networkName}/${connection.blockchainRid.toString(
+            "hex",
+        )}/transaction/${receipt.transactionRid.toString("hex")}`;
     } catch (error) {
         console.error("Debug - Error Details:", error);
         return `Error sending the Chromia asset. Ensure the recipient address, asset ID, and amount are correct. Details: ${error}`;
-    }    
+    }
 }


### PR DESCRIPTION
# Relates to:

No specific issue or ticket – enhancement to Chromia functionality in the GOAT SDK.

# Background

## What does this PR do?

- Adds support for sending arbitrary Chromia assets on custom chains.
- Introduces convenient configurations for mainnet and testnet setups.
- Provides transaction explorer links dynamically based on the network and blockchain RID.

# Testing

## Steps for the reviewer to test these changes

1. Go to the `typescript/examples/vercel-ai/chromia` directory.
2. Replace the `.env` file with your test setup.
3. Test sending assets on both mainnet and testnet by prompting actions like:
   - **Send 0.1 CHR to an address on mainnet.**
   - **Send 0.2 CHR to an address on testnet.**
4. Confirm that the explorer link is generated correctly for each transaction.

## Detailed testing results

| Method     | Prompt                                 | Screenshot                                                   | Transaction Link                                                                                          |
|------------|---------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| Send Asset | Send 11 CHR to `e9d9...d12e` on testnet | ![Chromia transfer](https://github.com/user-attachments/assets/c4737a23-70cc-41e9-a112-da3eeac28f9c) | [Transaction link](https://explorer.chromia.com/testnet/090bcd47149fbb66f02489372e88a454e7a5645adde82125d40df1ef0c76f874/transaction/982c0cfc7a338308e3ce71fbd9b8509fb7bb4d7eb43fd8a96f02525b6cbb5968) |

# Docs

- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation. If a docs change is needed: I have updated the documentation accordingly.

## For plugins

- [x] I have tested this change locally with key pair wallets.
- [x] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.).
- [x] Package exists in the [GOAT workspace file](https://github.com/goat-sdk/goat/blob/main/goat.code-workspace).

## Discord username
zilliun