### PR TITLE
Remove unused imports with new linter rule

### DIFF
--- a/typescript/biome.json
+++ b/typescript/biome.json
@@ -23,6 +23,7 @@
         "rules": {
             "recommended": true,
             "correctness": {
+                "noUnusedImports": "warn",
                 "useExhaustiveDependencies": "warn"
             },
             "style": {

--- a/typescript/examples/vercel-ai/headless-checkout/index.ts
+++ b/typescript/examples/vercel-ai/headless-checkout/index.ts
@@ -4,7 +4,7 @@ import { generateText } from "ai";
 import { http } from "viem";
 import { createWalletClient } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { base, baseSepolia, sepolia } from "viem/chains";
+import { baseSepolia } from "viem/chains";
 
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
 

--- a/typescript/examples/vercel-ai/modespray/index.ts
+++ b/typescript/examples/vercel-ai/modespray/index.ts
@@ -4,7 +4,7 @@ import { generateText } from "ai";
 import { http, createWalletClient } from "viem";
 
 import { privateKeyToAccount } from "viem/accounts";
-import { mode, modeTestnet } from "viem/chains";
+import { modeTestnet } from "viem/chains";
 
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
 

--- a/typescript/packages/plugins/coingecko/src/request.ts
+++ b/typescript/packages/plugins/coingecko/src/request.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 /**
  * Helper function to make requests to the CoinGecko API
  * @param endpointUrl - The full URL of the CoinGecko API endpoint

--- a/typescript/packages/plugins/crossmint-headless-checkout/src/crossmint-headless-checkout.plugin.ts
+++ b/typescript/packages/plugins/crossmint-headless-checkout/src/crossmint-headless-checkout.plugin.ts
@@ -1,5 +1,5 @@
 import { Crossmint, CrossmintApiClient, createCrossmint } from "@crossmint/common-sdk-base";
-import { Chain, PluginBase, WalletClientBase, createTool } from "@goat-sdk/core";
+import { Chain, PluginBase, createTool } from "@goat-sdk/core";
 import { z } from "zod";
 
 import { EVMWalletClient } from "@goat-sdk/wallet-evm";

--- a/typescript/packages/plugins/dexscreener/src/dexscreener.plugin.ts
+++ b/typescript/packages/plugins/dexscreener/src/dexscreener.plugin.ts
@@ -1,4 +1,4 @@
-import { PluginBase, createTool } from "@goat-sdk/core";
+import { PluginBase } from "@goat-sdk/core";
 import type { Chain, WalletClientBase } from "@goat-sdk/core";
 import { DexscreenerService } from "./dexscreener.service";
 

--- a/typescript/packages/plugins/ironclad/src/ironclad.plugin.ts
+++ b/typescript/packages/plugins/ironclad/src/ironclad.plugin.ts
@@ -1,4 +1,4 @@
-import { type Chain, PluginBase, ToolBase } from "@goat-sdk/core";
+import { type Chain, PluginBase } from "@goat-sdk/core";
 import type { EVMWalletClient } from "@goat-sdk/wallet-evm";
 import { mode } from "viem/chains";
 import { IroncladService } from "./ironclad.service";

--- a/typescript/packages/plugins/jupiter/src/parameters.ts
+++ b/typescript/packages/plugins/jupiter/src/parameters.ts
@@ -1,11 +1,5 @@
 import { createToolParameters } from "@goat-sdk/core";
-import {
-    type QuoteGetRequest,
-    QuoteGetSwapModeEnum,
-    type QuoteResponse,
-    type SwapInfo,
-    type SwapPostRequest,
-} from "@jup-ag/api";
+import { QuoteGetSwapModeEnum, type QuoteResponse, type SwapInfo, type SwapPostRequest } from "@jup-ag/api";
 import { z } from "zod";
 
 export class GetQuoteParameters extends createToolParameters(

--- a/typescript/packages/plugins/kim/src/kim.service.ts
+++ b/typescript/packages/plugins/kim/src/kim.service.ts
@@ -16,7 +16,6 @@ import {
     ExactOutputParams,
     ExactOutputSingleParams,
     GetSwapRouterAddressParams,
-    GlobalStateResponseParams,
     IncreaseLiquidityParams,
     MintParams,
 } from "./parameters";

--- a/typescript/packages/plugins/mode-governance/src/index.ts
+++ b/typescript/packages/plugins/mode-governance/src/index.ts
@@ -2,7 +2,6 @@ import { Chain, PluginBase } from "@goat-sdk/core";
 import { EVMWalletClient } from "@goat-sdk/wallet-evm";
 import { mode } from "viem/chains";
 import { ModeGovernanceService } from "./mode-governance.service";
-import { GetBalanceParameters, GetStakeInfoParameters, StakeParameters } from "./parameters";
 
 const SUPPORTED_CHAINS = [mode];
 

--- a/typescript/packages/plugins/orca/src/tools/openSingleSidedPosition.ts
+++ b/typescript/packages/plugins/orca/src/tools/openSingleSidedPosition.ts
@@ -1,6 +1,6 @@
 import { Wallet } from "@coral-xyz/anchor";
 import { SolanaWalletClient } from "@goat-sdk/wallet-solana";
-import { Percentage, TransactionBuilder, resolveOrCreateATAs } from "@orca-so/common-sdk";
+import { Percentage } from "@orca-so/common-sdk";
 import {
     NO_TOKEN_EXTENSION_CONTEXT,
     ORCA_WHIRLPOOL_PROGRAM_ID,

--- a/typescript/packages/plugins/renzo/src/renzo.service.ts
+++ b/typescript/packages/plugins/renzo/src/renzo.service.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@goat-sdk/core";
 import { EVMWalletClient } from "@goat-sdk/wallet-evm";
-import { formatUnits, parseUnits } from "viem";
+import { parseUnits } from "viem";
 import { EZETH_ABI } from "./abi/ezeth";
 import { RENZO_ABI } from "./abi/renzo";
 import { BalanceOfParams, DepositETHParams, DepositParams, GetDepositAddressParams } from "./parameters";

--- a/typescript/packages/plugins/zerodev-global-address/src/zerodev-global-address.service.ts
+++ b/typescript/packages/plugins/zerodev-global-address/src/zerodev-global-address.service.ts
@@ -1,9 +1,9 @@
 import { Tool } from "@goat-sdk/core";
-import { CreateGlobalAddressParams, FLEX, createCall, createGlobalAddress } from "@zerodev/global-address";
-import { type Address, erc20Abi, getAddress } from "viem";
+import { FLEX, createCall, createGlobalAddress } from "@zerodev/global-address";
+import { type Address, erc20Abi } from "viem";
 import { arbitrum, base, mainnet, mode, optimism, scroll } from "viem/chains";
 import { CreateGlobalAddressConfigParams } from "./parameters";
-import { GlobalAddressConfig, GlobalAddressResponse, TokenActions, TokenConfig } from "./types";
+import { GlobalAddressResponse, TokenActions, TokenConfig } from "./types";
 
 interface FormattedFee {
     chainName: string;

--- a/typescript/packages/wallets/chromia/src/ChromiaWalletClient.ts
+++ b/typescript/packages/wallets/chromia/src/ChromiaWalletClient.ts
@@ -2,7 +2,6 @@ import { type Connection, type KeyStoreInteractor, createAmount } from "@chromia
 import { WalletClientBase } from "@goat-sdk/core";
 import type { DictPair, IClient, QueryObject, RawGtv } from "postchain-client";
 import { formatUnits } from "viem";
-import { CHROMIA_CONFIG } from "./consts";
 import type { ChromiaTransaction } from "./types/ChromiaTransaction";
 
 export type ChromiaWalletCtorParams = {


### PR DESCRIPTION
# Background
We can clean up unused imports by adding a new linter rule: `noUnusedImports`. There were 13 files with unused imports.

## What does this PR do?
 - Adds a new linter rule: `noUnusedImports`
 - Fixes 13 files using `pnpm lint:fix`

# Testing
I don't believe any testing is required. There should be no chance of regression. The Biome rule has a safe fix as described [here](https://biomejs.dev/linter/rules/no-unused-imports/).

## Discord username
toozol1