### PR TITLE
Proposal: Add adapter base class

### DIFF
--- a/typescript/examples/virtuals-game/viem/package.json
+++ b/typescript/examples/virtuals-game/viem/package.json
@@ -10,12 +10,12 @@
     "license": "MIT",
     "dependencies": {
         "@ai-sdk/openai": "^1.0.4",
-        "@goat-sdk/adapter-vercel-ai": "workspace:*",
         "@goat-sdk/core": "workspace:*",
         "@goat-sdk/plugin-erc20": "workspace:*",
         "@goat-sdk/wallet-evm": "workspace:*",
         "@goat-sdk/plugin-kim": "workspace:*",
         "@goat-sdk/wallet-viem": "workspace:*",
+        "@goat-sdk/adapter-virtuals-game": "workspace:*",
         "@virtuals-protocol/game": "0.1.4",
         "ai": "4.0.27",
         "ajv": "8.17.1",

--- a/typescript/examples/virtuals-game/viem/toolCalling.ts
+++ b/typescript/examples/virtuals-game/viem/toolCalling.ts
@@ -13,7 +13,7 @@ import { mode } from "viem/chains";
 
 import { openai } from "@ai-sdk/openai";
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
-import { MODE, PEPE, USDC, erc20 } from "@goat-sdk/plugin-erc20";
+import { MODE, USDC, erc20 } from "@goat-sdk/plugin-erc20";
 import { kim } from "@goat-sdk/plugin-kim";
 import { sendETH } from "@goat-sdk/wallet-evm";
 import { viem } from "@goat-sdk/wallet-viem";

--- a/typescript/packages/adapters/virtuals-game/README.md
+++ b/typescript/packages/adapters/virtuals-game/README.md
@@ -1,0 +1,16 @@
+# Goat Adapter Virtuals Game 🐐 - TypeScript
+
+## Installation
+```
+npm install @goat-sdk/adapter-virtuals-game
+```
+
+## Goat
+
+<div align="center">
+Go out and eat some grass.
+
+[Docs](https://ohmygoat.dev) | [Examples](https://github.com/goat-sdk/goat/tree/main/typescript/examples) | [Discord](https://discord.gg/goat-sdk)</div>
+
+## Goat 🐐
+Goat 🐐 (Great Onchain Agent Toolkit) is an open-source library enabling AI agents to interact with blockchain protocols and smart contracts via their own wallets.

--- a/typescript/packages/adapters/virtuals-game/package.json
+++ b/typescript/packages/adapters/virtuals-game/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@goat-sdk/adapter-virtuals-game",
+    "version": "0.2.5",
+    "sideEffects": false,
+    "files": ["dist/**/*", "README.md", "package.json"],
+    "scripts": {
+        "build": "tsup",
+        "clean": "rm -rf dist",
+        "test": "vitest run --passWithNoTests"
+    },
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "dependencies": {
+        "@virtuals-protocol/game": "^0.1.6",
+        "@goat-sdk/core": "workspace:*",
+        "zod": "catalog:",
+        "ajv": "^8.17.1",
+        "zod-to-json-schema": "3.24.1"
+    },
+    "peerDependencies": {
+        "@virtuals-protocol/game": "^0.1.6",
+        "@goat-sdk/core": "workspace:*"
+    },
+    "homepage": "https://ohmygoat.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/goat-sdk/goat.git"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/goat-sdk/goat/issues"
+    },
+    "keywords": ["ai", "agents", "web3"]
+}

--- a/typescript/packages/adapters/virtuals-game/src/index.ts
+++ b/typescript/packages/adapters/virtuals-game/src/index.ts
@@ -1,0 +1,47 @@
+import { AdapterBase, ToolBase } from "@goat-sdk/core";
+import { ExecutableGameFunctionResponse, ExecutableGameFunctionStatus, GameFunction } from "@virtuals-protocol/game";
+import type { JSONSchemaType } from "ajv";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+type VirtualsGameAdaptedTools = GameFunction<
+    {
+        name: string;
+        description: string;
+    }[]
+>;
+
+export class VirtualsGameAdapter extends AdapterBase<VirtualsGameAdaptedTools> {
+    protected adaptTool(tool: ToolBase): VirtualsGameAdaptedTools {
+        // biome-ignore lint/suspicious/noExplicitAny: Fix types later
+        const schema = zodToJsonSchema(tool.parameters as any, {
+            target: "jsonSchema7",
+        }) as JSONSchemaType<typeof tool.parameters>;
+
+        const properties = Object.keys(schema.properties);
+
+        const args = properties.map((property) => ({
+            name: property,
+            description: schema.properties[property].description ?? "",
+        }));
+
+        return new GameFunction({
+            name: tool.name,
+            description: tool.description,
+            args: args,
+            executable: async (args) => {
+                try {
+                    const result = await tool.execute(args);
+                    return new ExecutableGameFunctionResponse(
+                        ExecutableGameFunctionStatus.Done,
+                        JSON.stringify(result),
+                    );
+                } catch (e) {
+                    return new ExecutableGameFunctionResponse(
+                        ExecutableGameFunctionStatus.Failed,
+                        `Failed to execute tool: ${e}`,
+                    );
+                }
+            },
+        });
+    }
+}

--- a/typescript/packages/adapters/virtuals-game/tsconfig.json
+++ b/typescript/packages/adapters/virtuals-game/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../../tsconfig.base.json",
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/adapters/virtuals-game/tsup.config.ts
+++ b/typescript/packages/adapters/virtuals-game/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { treeShakableConfig } from "../../../tsup.config.base";
+
+export default defineConfig({
+    ...treeShakableConfig,
+});

--- a/typescript/packages/adapters/virtuals-game/turbo.json
+++ b/typescript/packages/adapters/virtuals-game/turbo.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "extends": ["//"],
+    "tasks": {
+        "build": {
+            "inputs": ["src/**", "tsup.config.ts", "!./**/*.test.{ts,tsx}", "tsconfig.json"],
+            "dependsOn": ["^build"],
+            "outputs": ["dist/**"]
+        }
+    }
+}

--- a/typescript/packages/core/src/classes/AdapterBase.ts
+++ b/typescript/packages/core/src/classes/AdapterBase.ts
@@ -1,0 +1,39 @@
+import { getTools } from "../utils";
+import { PluginBase } from "./PluginBase";
+import { ToolBase } from "./ToolBase";
+import { WalletClientBase } from "./WalletClientBase";
+
+type TAdapterParams = {
+    wallet: WalletClientBase;
+    plugins: PluginBase<WalletClientBase>[];
+};
+
+export abstract class AdapterBase<TAdaptedTool> {
+    private params: TAdapterParams;
+
+    constructor(params: TAdapterParams) {
+        this.params = params;
+    }
+
+    /**
+     * Get all the converted tools for the target framework
+     *
+     * @returns A list of tools adapted for the target framework
+     */
+    public async getAdaptedTools(): Promise<TAdaptedTool[]> {
+        const tools = await getTools({
+            wallet: this.params.wallet,
+            plugins: this.params.plugins,
+        });
+
+        return tools.map((tool: ToolBase) => this.adaptTool(tool));
+    }
+
+    /**
+     * Converts a tool for it to be usable with the target framework
+     *
+     * @param tool
+     * @returns A tool adapted for the target framework
+     */
+    protected abstract adaptTool(tool: ToolBase): TAdaptedTool;
+}

--- a/typescript/packages/core/src/classes/index.ts
+++ b/typescript/packages/core/src/classes/index.ts
@@ -1,3 +1,4 @@
 export * from "./PluginBase";
 export * from "./ToolBase";
 export * from "./WalletClientBase";
+export * from "./AdapterBase";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -832,9 +832,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^1.0.4
         version: 1.0.13(zod@3.23.8)
-      '@goat-sdk/adapter-vercel-ai':
+      '@goat-sdk/adapter-virtuals-game':
         specifier: workspace:*
-        version: link:../../../packages/adapters/vercel-ai
+        version: link:../../../packages/adapters/virtuals-game
       '@goat-sdk/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -953,6 +953,24 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 3.23.8
+
+  packages/adapters/virtuals-game:
+    dependencies:
+      '@goat-sdk/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@virtuals-protocol/game':
+        specifier: ^0.1.6
+        version: 0.1.6
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
+      zod-to-json-schema:
+        specifier: 3.24.1
+        version: 3.24.1(zod@3.23.8)
 
   packages/core:
     dependencies:
@@ -5785,6 +5803,9 @@ packages:
 
   '@virtuals-protocol/game@0.1.4':
     resolution: {integrity: sha512-H8Tr3CYPwVxCeJGsGqvKAWnJHPiAeeLk2c32p/O1ZC1GMEMoJTPgKVtnDE7xY7AOQn69jOVK0BQRNZH11gvdlg==}
+
+  '@virtuals-protocol/game@0.1.6':
+    resolution: {integrity: sha512-zbhgjdPXpva/mS/uC295mBGtgLWg3x7bZMGMGoQBrH7OFmQYilebB42iEt8sQCWqqcCfWsnFbDIBpVqb+ioSYg==}
 
   '@vitest/expect@0.34.6':
     resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
@@ -18386,6 +18407,12 @@ snapshots:
   '@upstash/vector@1.1.7': {}
 
   '@virtuals-protocol/game@0.1.4':
+    dependencies:
+      axios: 1.7.9
+    transitivePeerDependencies:
+      - debug
+
+  '@virtuals-protocol/game@0.1.6':
     dependencies:
       axios: 1.7.9
     transitivePeerDependencies:


### PR DESCRIPTION
# Background
While playing around with the new example added for the Virtuals G.A.M.E framework in #207, I noticed that we're essentially embedding a new adapter inside the example.

Then it got me thinking that, in essence, every adapter performs the following steps:

- Takes in a list of "GOAT tools"
- Converts each "GOAT tool" to a tool understandable by the target framework
- Returns the converted list of tools

## What does this PR do?
I think it could be beneficial to have an adapter base class which has:
- An abstract method which users can implement to define the logic for converting a tool for a given target framework
- A concrete method which takes in the list of "GOAT tools" and returns the list of converted tools

An example implementation would be what I added in this PR:
- Add a new GAME adapter: `VirtualsGameAdapter` that extends `AdapterBase`
- Call `await adapter.getAdaptedTools();` in the GAME example to get the list of converted tools

## Benefits
- Standardization of adapter creation
- Less duplicate code (every adapter maps through tools and converts them for the target framework)

## Next steps
If this PR is approved, I can change existing adapters to leverage the new base class.

# Testing
There should no change in functionality. I only refactored code related to adapter usage.

## Discord username
toozol1