### PR TITLE
(fix) CJS distribution for wallet-zilliqa

### DIFF
--- a/typescript/packages/wallets/zilliqa/src/ZilliqaWalletClient.ts
+++ b/typescript/packages/wallets/zilliqa/src/ZilliqaWalletClient.ts
@@ -27,10 +27,15 @@ export abstract class ZilliqaWalletClient extends WalletClientBase {
 export class ZilliqaJSViemWalletClient extends ZilliqaWalletClient {
     zilliqa: Zilliqa;
     viem: ViemEVMWalletClient;
-    chainId = 0;
+    // This was originally a static assignment; however, this causes
+    // typescript to emit invalid JS when compiling the CJS version of
+    // the distribution package, so it is now initialized in the
+    // constructor.
+    chainId;
 
     constructor(client: ViemWalletClient, node: string, account: Account, chainId: number, options?: ViemOptions) {
         super();
+        this.chainId = 0;
         this.viem = new ViemEVMWalletClient(client, options);
         this.zilliqa = new Zilliqa(node);
         this.zilliqa.wallet.addByPrivateKey(account.privateKey);


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

fixes #241 

<!-- This risks section is to be filled out before final review and merge. -->

# Background

## What does this PR do?

It removes the static initialization of `chainId`, which causes ts to no longer generate invalid Javascript when exporting CJS modules.

# Testing
<!-- Steps for the reviewer to test these changes -->

Attempt to import the npm-released version of `wallet-zilliqa`.


## Detailed testing results

I'm going to n/a this until requested to do so, because there's quite a lot of of it and this is quite a small PR - do yell if you want the full shebang.
<!-- 
Show that you've tested each function on your plugin/adapter/wallet. To do so simply:
1. Go to the examples directory and choose an example to test with
2. Import your plugin/wallet/adapter
3. Test each action and fill the table below with a screenshot and an example transaction showing that your changes worked
4. Don't push any changes to the example dir
-->

| Method | Prompt | Screenshot | Transaction Link |
|----------|--------|-------|------------------|
| Action #1 | Prompt to get it to take that action | Screenshot of the result | Transaction link |
| Action #2 | Prompt to get it to take that action | Screenshot of the result | Transaction link |


# Docs

no change required to project docs.
<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->

## For plugins
- [X ] I have tested this change locally with key pair wallets
- [ n/a] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)
- [ X] Package exists in the [goat workspace file](https://github.com/goat-sdk/goat/blob/main/goat.code-workspace)

## Discord username

_naranek

