### PR TITLE
Python fix: deal with several async settings upon calling async tools

### DIFF
--- a/python/src/goat-sdk/goat/classes/plugin_base.py
+++ b/python/src/goat-sdk/goat/classes/plugin_base.py
@@ -1,5 +1,7 @@
 import asyncio
 import inspect
+import threading
+import concurrent.futures
 from abc import ABC, abstractmethod
 from typing import List, Any, TypeVar, Generic
 
@@ -103,6 +105,30 @@ class PluginBase(Generic[TWalletClient], ABC):
         Returns:
             The result of the tool execution
         """
+
+        def _run_coroutine_in_new_thread(coro):
+            """Run a coroutine in a new thread with its own event loop."""
+            result = None
+            exception = None
+            
+            def run_coro():
+                nonlocal result, exception
+                loop = asyncio.new_event_loop()
+                try:
+                    result = loop.run_until_complete(coro)
+                except Exception as e:
+                    exception = e
+                finally:
+                    loop.close()
+            
+            thread = threading.Thread(target=run_coro)
+            thread.start()
+            thread.join()
+            
+            if exception:
+                raise exception
+            return result
+
         wallet_client_index = tool_metadata.wallet_client.get("index", 0)
         parameters_index = tool_metadata.parameters.get("index", 0)
         args = [None] * max(wallet_client_index or 0, parameters_index)
@@ -116,6 +142,23 @@ class PluginBase(Generic[TWalletClient], ABC):
         method = getattr(tool_provider, tool_metadata.target.__name__)
         result = method(*args)
 
+        # Handle coroutine results in three cases:
+        # 1. If there's an existing event loop and it's not running: use it directly with run_until_complete
+        # 2. If there's an existing event loop and it's running: create a new thread with its own event loop to avoid deadlock
+        # 3. If there's no event loop: create a new one and use it, then set it as the current event loop to be reused
         if inspect.iscoroutine(result):
-            return asyncio.get_event_loop().run_until_complete(result)
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    # Case 2: Loop is running, run in new thread
+                    return _run_coroutine_in_new_thread(result)
+                else:
+                    # Case 1: Loop exists but not running
+                    return loop.run_until_complete(result)
+            except RuntimeError:
+                # Case 3: No loop exists, create new one
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                return loop.run_until_complete(result)
+
         return result

--- a/python/src/goat-sdk/goat/classes/plugin_base.py
+++ b/python/src/goat-sdk/goat/classes/plugin_base.py
@@ -150,13 +150,10 @@ class PluginBase(Generic[TWalletClient], ABC):
             try:
                 loop = asyncio.get_event_loop()
                 if loop.is_running():
-                    # Case 2: Loop is running, run in new thread
                     return _run_coroutine_in_new_thread(result)
                 else:
-                    # Case 1: Loop exists but not running
                     return loop.run_until_complete(result)
             except RuntimeError:
-                # Case 3: No loop exists, create new one
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
                 return loop.run_until_complete(result)

--- a/python/src/goat-sdk/goat/classes/plugin_base.py
+++ b/python/src/goat-sdk/goat/classes/plugin_base.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import threading
-import concurrent.futures
 from abc import ABC, abstractmethod
 from typing import List, Any, TypeVar, Generic
 

--- a/python/src/goat-sdk/pyproject.toml
+++ b/python/src/goat-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "goat-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Goat 🐐 (Great Onchain Agent Toolkit) is an open-source framework for connecting AI agents to any onchain app"
 authors = ["Andrea Villa <andreakarimodm@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes #245 

As noted by #245 , our current approach to async tool calling is not robust.
This PR addresses the problem by considering these cases whenever an async tool is being called:

1. If there's an existing event loop and it's not running: use it directly with run_until_complete.
2. If there's an existing event loop and it's running: create a new thread with its own event loop to avoid deadlock.
3. If there's no event loop: create a new one and use it, then set it as the current event loop to be reused.