### PR TITLE
Fix PlunderSwap plugin API: remove ignored tool parameter.

### DIFF
--- a/typescript/.changeset/breezy-pants-know.md
+++ b/typescript/.changeset/breezy-pants-know.md
@@ -1,0 +1,5 @@
+---
+"@goat-sdk/plugin-plunderswap": minor
+---
+
+Remove parameter from PlunderSwap swap tool API.

--- a/typescript/packages/plugins/plunderswap/src/types.ts
+++ b/typescript/packages/plugins/plunderswap/src/types.ts
@@ -43,7 +43,6 @@ export class SwapParameters extends createToolParameters(
             .describe(
                 "minimum bound on how much of the other token, the last in the token path, must be received in exchange",
             ),
-        toAddress: z.string().describe("address of the account in which to deposit the tokens received in exchange"),
         deadline: z.coerce.date().describe("by when the exchange must be completed"),
     }),
 ) {}


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

No issue/ticket.

# Background

## What does this PR do?

Removes `toAddress` parameter from the `plunderswap_swap` tool: it is misleading to offer it because the tool ignores it.

(For safety, the tool's actual implementation always deposits currency back into the user's wallet. We don't want the user accidentally giving somebody else the tokens because their address was in the conversation history.)

# Testing

Use the instructions from the description of https://github.com/elizaOS/eliza/pull/3267 to get going with ElizaOS. Locally, adjust `packages/plugin-zilliqa/package.json` to have ElizaOS' `@goat-sdk/plugin-plunderswap` dependency link to wherever this branch's `typescript/packages/plugins/plunderswap` is.

Try doing any swap with `plunderswap_swap` and see that the tokens are deposited back into your wallet.

<!-- Steps for the reviewer to test these changes -->

## Detailed testing results

![swap-1](https://github.com/user-attachments/assets/09453e81-a187-45a5-88c6-1d75e274a71f)

![swap-2](https://github.com/user-attachments/assets/ac2440d8-8677-485e-ac6b-ab76cecc768e)

Links to transactions:

1. Wrap the ZIL: https://otterscan.testnet.zilliqa.com/tx/0x479c2970d396b60651069483ca27d6da2f6bf1e346a552363cc5e2740eb29dba
2. Do the swap: approve spending in https://otterscan.testnet.zilliqa.com/tx/0x1c6d647cb7e651c5d4d0ef799af2f8d5422e29945b9e9b8b9391dd6d7763a377 then swap in https://otterscan.testnet.zilliqa.com/tx/0xfb8d3e9dad171b96820c3c7cd5f426c6e8f02cc2114c8fd20c813ebdc0cb51a6.

# Docs
<!--
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->
My changes do not require a change to the project documentation.

## For plugins
- [x] I have tested this change locally with key pair wallets
- [ ] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)
- [ ] Package exists in the [goat workspace file](https://github.com/goat-sdk/goat/blob/main/goat.code-workspace)

## Discord username

none