### PR TITLE
SolanaSmartWallets: Adapt quickstart

### DIFF
--- a/python/examples/langchain/crossmint/solana_smart_wallet_example.py
+++ b/python/examples/langchain/crossmint/solana_smart_wallet_example.py
@@ -27,20 +27,6 @@ def main():
     })
     print(f"Created wallet with address: {wallet.get_address()}")
     
-    signer_response = wallet.register_delegated_signer(
-        "solana-keypair:BvzKvn6nUUAYtKu2pH3h5SbUkUNcRPQawg3TYz8aB8Zr",
-    )
-    print(f"Registered delegated signer: {signer_response}")
-    
-    signer_info = wallet.get_delegated_signer("solana-keypair:BvzKvn6nUUAYtKu2pH3h5SbUkUNcRPQawg3TYz8aB8Zr")
-    print(f"Delegated signer info: {signer_info}")
-    
-    signature = wallet.sign_message(
-        "Hello, Solana!",
-        required_signers=["solana-keypair:BvzKvn6nUUAYtKu2pH3h5SbUkUNcRPQawg3TYz8aB8Zr"]
-    )
-    print(f"Message signature: {signature}")
-    
     balance = wallet.balance_of(wallet.get_address())
     print(f"Wallet balance: {balance.value} {balance.symbol}")
 


### PR DESCRIPTION
# Background

## What does this PR do?
Just removes yet-unsupported operations from the solana smart wallet quickstart

## For plugins
- [ ] I have tested this change locally with key pair wallets
- [ ] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)
- [ ] Package exists in the [goat workspace file](https://github.com/goat-sdk/goat/blob/main/goat.code-workspace)

