### PR TITLE
Add plugin token-details

### DIFF
--- a/typescript/packages/plugins/token-info/package.json
+++ b/typescript/packages/plugins/token-info/package.json
@@ -1,11 +1,7 @@
 {
     "name": "@goat-sdk/plugin-token-info",
     "version": "1.0.0",
-    "files": [
-        "dist/**/*",
-        "README.md",
-        "package.json"
-    ],
+    "files": ["dist/**/*", "README.md", "package.json"],
     "scripts": {
         "build": "tsup",
         "clean": "rm -rf dist",
@@ -34,9 +30,5 @@
     "bugs": {
         "url": "https://github.com/goat-sdk/goat/issues"
     },
-    "keywords": [
-        "ai",
-        "agents",
-        "web3"
-    ]
+    "keywords": ["ai", "agents", "web3"]
 }

--- a/typescript/packages/plugins/token-info/package.json
+++ b/typescript/packages/plugins/token-info/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "@goat-sdk/plugin-token-info",
+    "version": "1.0.0",
+    "files": [
+        "dist/**/*",
+        "README.md",
+        "package.json"
+    ],
+    "scripts": {
+        "build": "tsup",
+        "clean": "rm -rf dist",
+        "test": "vitest run --passWithNoTests"
+    },
+    "sideEffects": false,
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "dependencies": {
+        "@goat-sdk/core": "workspace:*",
+        "@goat-sdk/wallet-evm": "workspace:*",
+        "viem": "catalog:",
+        "zod": "catalog:"
+    },
+    "peerDependencies": {
+        "@goat-sdk/core": "workspace:*",
+        "viem": "catalog:"
+    },
+    "homepage": "https://ohmygoat.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/goat-sdk/goat.git"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/goat-sdk/goat/issues"
+    },
+    "keywords": [
+        "ai",
+        "agents",
+        "web3"
+    ]
+}

--- a/typescript/packages/plugins/token-info/src/abi/erc20.ts
+++ b/typescript/packages/plugins/token-info/src/abi/erc20.ts
@@ -1,0 +1,487 @@
+export const ERC20_ABI = [
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "_bridge",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "_remoteToken",
+                type: "address",
+            },
+            {
+                internalType: "string",
+                name: "_name",
+                type: "string",
+            },
+            {
+                internalType: "string",
+                name: "_symbol",
+                type: "string",
+            },
+            {
+                internalType: "uint8",
+                name: "_decimals",
+                type: "uint8",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Approval",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "Burn",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "Mint",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Transfer",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "BRIDGE",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "REMOTE_TOKEN",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+        ],
+        name: "allowance",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "approve",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "balanceOf",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "bridge",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "_from",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "_amount",
+                type: "uint256",
+            },
+        ],
+        name: "burn",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "decimals",
+        outputs: [
+            {
+                internalType: "uint8",
+                name: "",
+                type: "uint8",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "subtractedValue",
+                type: "uint256",
+            },
+        ],
+        name: "decreaseAllowance",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "addedValue",
+                type: "uint256",
+            },
+        ],
+        name: "increaseAllowance",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "l1Token",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "l2Bridge",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "_to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "_amount",
+                type: "uint256",
+            },
+        ],
+        name: "mint",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "name",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "remoteToken",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "bytes4",
+                name: "_interfaceId",
+                type: "bytes4",
+            },
+        ],
+        name: "supportsInterface",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "pure",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "symbol",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "totalSupply",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "transfer",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "transferFrom",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "version",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+] as const;

--- a/typescript/packages/plugins/token-info/src/index.ts
+++ b/typescript/packages/plugins/token-info/src/index.ts
@@ -1,2 +1,1 @@
 export * from "./token-info.plugin";
-

--- a/typescript/packages/plugins/token-info/src/index.ts
+++ b/typescript/packages/plugins/token-info/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./token-info.plugin";
+

--- a/typescript/packages/plugins/token-info/src/parameters.ts
+++ b/typescript/packages/plugins/token-info/src/parameters.ts
@@ -6,4 +6,3 @@ export class TokenInfoParameters extends createToolParameters(
         symbol: z.string().min(1),
     }),
 ) {}
-

--- a/typescript/packages/plugins/token-info/src/parameters.ts
+++ b/typescript/packages/plugins/token-info/src/parameters.ts
@@ -1,0 +1,9 @@
+import { createToolParameters } from "@goat-sdk/core";
+import { z } from "zod";
+
+export class TokenInfoParameters extends createToolParameters(
+    z.object({
+        symbol: z.string().min(1),
+    }),
+) {}
+

--- a/typescript/packages/plugins/token-info/src/token-info.plugin.ts
+++ b/typescript/packages/plugins/token-info/src/token-info.plugin.ts
@@ -1,0 +1,38 @@
+import { type Chain, PluginBase } from "@goat-sdk/core";
+import type { EVMWalletClient } from "@goat-sdk/wallet-evm";
+import { TokenInfoService } from "./token-info.service";
+import {
+    base,
+    mode,
+    mantle,
+    arbitrum,
+    optimism,
+    polygon,
+    zksync,
+} from "viem/chains";
+
+const SUPPORTED_CHAINS = [
+    base,
+    mode,
+    mantle,
+    arbitrum,
+    optimism,
+    polygon,
+    zksync,
+];
+
+export type TokenInfoCtorParams = {
+    coingeckoApiKey: string;
+};
+
+export class TokenInfoPlugin extends PluginBase<EVMWalletClient> {
+    constructor(params: TokenInfoCtorParams) {
+        super("token-info", [new TokenInfoService(params.coingeckoApiKey)]);
+    }
+
+    supportsChain = (chain: Chain) =>
+        chain.type === "evm" && SUPPORTED_CHAINS.some((c) => c.id === chain.id);
+}
+
+export const tokenInfo = (params: TokenInfoCtorParams) =>
+    new TokenInfoPlugin(params);

--- a/typescript/packages/plugins/token-info/src/token-info.plugin.ts
+++ b/typescript/packages/plugins/token-info/src/token-info.plugin.ts
@@ -1,25 +1,9 @@
 import { type Chain, PluginBase } from "@goat-sdk/core";
 import type { EVMWalletClient } from "@goat-sdk/wallet-evm";
+import { arbitrum, base, mantle, mode, optimism, polygon, zksync } from "viem/chains";
 import { TokenInfoService } from "./token-info.service";
-import {
-    base,
-    mode,
-    mantle,
-    arbitrum,
-    optimism,
-    polygon,
-    zksync,
-} from "viem/chains";
 
-const SUPPORTED_CHAINS = [
-    base,
-    mode,
-    mantle,
-    arbitrum,
-    optimism,
-    polygon,
-    zksync,
-];
+const SUPPORTED_CHAINS = [base, mode, mantle, arbitrum, optimism, polygon, zksync];
 
 export type TokenInfoCtorParams = {
     coingeckoApiKey: string;
@@ -30,9 +14,7 @@ export class TokenInfoPlugin extends PluginBase<EVMWalletClient> {
         super("token-info", [new TokenInfoService(params.coingeckoApiKey)]);
     }
 
-    supportsChain = (chain: Chain) =>
-        chain.type === "evm" && SUPPORTED_CHAINS.some((c) => c.id === chain.id);
+    supportsChain = (chain: Chain) => chain.type === "evm" && SUPPORTED_CHAINS.some((c) => c.id === chain.id);
 }
 
-export const tokenInfo = (params: TokenInfoCtorParams) =>
-    new TokenInfoPlugin(params);
+export const tokenInfo = (params: TokenInfoCtorParams) => new TokenInfoPlugin(params);

--- a/typescript/packages/plugins/token-info/src/token-info.service.ts
+++ b/typescript/packages/plugins/token-info/src/token-info.service.ts
@@ -1,9 +1,9 @@
-import { TokenInfo, CoinGeckoToken } from "./types";
+import { Tool } from "@goat-sdk/core";
+import { EVMWalletClient } from "@goat-sdk/wallet-evm";
+import { ERC20_ABI } from "./abi/erc20";
 import { TokenInfoParameters } from "./parameters";
 import { KNOWN_TOKENS } from "./token";
-import { EVMWalletClient } from "@goat-sdk/wallet-evm";
-import { Tool } from "@goat-sdk/core";
-import { ERC20_ABI } from "./abi/erc20";
+import { CoinGeckoToken, TokenInfo } from "./types";
 
 export class TokenInfoService {
     private readonly coingeckoBaseUrl: string;
@@ -18,32 +18,17 @@ export class TokenInfoService {
         name: "get_token_info",
         description: "Get token information for a given symbol",
     })
-    async getTokenInfo(
-        walletClient: EVMWalletClient,
-        parameters: TokenInfoParameters,
-    ): Promise<TokenInfo | null> {
-        console.log("walletClient", walletClient);
+    async getTokenInfo(walletClient: EVMWalletClient, parameters: TokenInfoParameters): Promise<TokenInfo | null> {
         const chainId = walletClient.getChain().id;
-        console.log(
-            `Searching for token: ${parameters.symbol} on chain: ${chainId}`,
-        );
 
         // First check known tokens
-        const knownToken =
-            KNOWN_TOKENS[
-                parameters.symbol.toUpperCase() as keyof typeof KNOWN_TOKENS
-            ];
+        const knownToken = KNOWN_TOKENS[parameters.symbol.toUpperCase() as keyof typeof KNOWN_TOKENS];
         if (knownToken) {
-            console.log(`Found token in known tokens list: ${knownToken.name}`);
             const chainData = knownToken.chains[chainId.toString()];
             if (!chainData) {
-                console.log(
-                    `Token ${knownToken.symbol} not available on chain ${chainId}`,
-                );
                 return null; // Token not available on current network
             }
 
-            console.log(`Returning known token data for ${knownToken.symbol}`);
             return {
                 symbol: knownToken.symbol,
                 name: knownToken.name,
@@ -52,27 +37,18 @@ export class TokenInfoService {
             };
         }
 
-        console.log(`Token not found in known list, trying CoinGecko API...`);
         // If not found, try CoinGecko
         try {
-            const response = await fetch(
-                `${this.coingeckoBaseUrl}coins/list?include_platform=true`,
-                {
-                    method: "GET",
-                    headers: {
-                        accept: "application/json",
-                        "x-cg-demo-api-key": this.apiKey,
-                    },
+            const response = await fetch(`${this.coingeckoBaseUrl}coins/list?include_platform=true`, {
+                method: "GET",
+                headers: {
+                    accept: "application/json",
+                    "x-cg-demo-api-key": this.apiKey,
                 },
-            );
+            });
             const data: CoinGeckoToken[] = await response.json();
 
-            const matches = data.filter(
-                (token) =>
-                    token.symbol.toLowerCase() ===
-                    parameters.symbol.toLowerCase(),
-            );
-            console.log(`Found ${matches.length} matching tokens on CoinGecko`);
+            const matches = data.filter((token) => token.symbol.toLowerCase() === parameters.symbol.toLowerCase());
             if (matches.length > 0) {
                 console.log(
                     "Matching tokens:",
@@ -84,24 +60,15 @@ export class TokenInfoService {
                 );
             }
             for (const token of matches) {
-                console.log(`Checking token: ${token.name}`);
-                const platformAddress = this.getPlatformAddressForChainId(
-                    token.platforms,
-                    chainId,
-                );
+                const platformAddress = this.getPlatformAddressForChainId(token.platforms, chainId);
 
                 if (platformAddress) {
-                    console.log(
-                        `Found valid contract address for ${token.name}`,
-                    );
                     const tokenDecimals = await walletClient.read({
                         address: platformAddress as `0x${string}`,
                         abi: ERC20_ABI,
                         functionName: "decimals",
                     });
-                    const tokenDecimalsParsed = (
-                        tokenDecimals as { value: number }
-                    ).value;
+                    const tokenDecimalsParsed = (tokenDecimals as { value: number }).value;
                     return {
                         symbol: token.symbol.toUpperCase(),
                         name: token.name,
@@ -109,15 +76,9 @@ export class TokenInfoService {
                         decimals: tokenDecimalsParsed,
                     };
                 }
-                console.log(
-                    `No valid contract address found for ${token.name} on chain ${chainId}`,
-                );
             }
-
-            console.log(`No matching tokens found on CoinGecko`);
             return null;
         } catch (error) {
-            console.error(`CoinGecko API error:`, error);
             return null;
         }
     }
@@ -138,25 +99,13 @@ export class TokenInfoService {
             34443: "mode",
             // Add more mappings as needed
         };
-
         const platformIdentifier = platformMap[chainId];
-        console.log(`Platform identifier: ${platformIdentifier}`);
         if (!platformIdentifier) {
-            console.log(`No platform mapping found for chain ID ${chainId}`);
             return null;
         }
-
         if (platforms[platformIdentifier]) {
-            console.log(
-                `Found contract address on platform ${platformIdentifier}: ${platforms[platformIdentifier]}`,
-            );
             return platforms[platformIdentifier];
         }
-
-        console.log(
-            `No contract address found for chain ${chainId} in platforms:`,
-            platforms,
-        );
         return null;
     }
 }

--- a/typescript/packages/plugins/token-info/src/token-info.service.ts
+++ b/typescript/packages/plugins/token-info/src/token-info.service.ts
@@ -1,0 +1,162 @@
+import { TokenInfo, CoinGeckoToken } from "./types";
+import { TokenInfoParameters } from "./parameters";
+import { KNOWN_TOKENS } from "./token";
+import { EVMWalletClient } from "@goat-sdk/wallet-evm";
+import { Tool } from "@goat-sdk/core";
+import { ERC20_ABI } from "./abi/erc20";
+
+export class TokenInfoService {
+    private readonly coingeckoBaseUrl: string;
+    private readonly apiKey: string;
+
+    constructor(apiKey: string) {
+        this.coingeckoBaseUrl = "https://api.coingecko.com/api/v3/";
+        this.apiKey = apiKey;
+    }
+
+    @Tool({
+        name: "get_token_info",
+        description: "Get token information for a given symbol",
+    })
+    async getTokenInfo(
+        walletClient: EVMWalletClient,
+        parameters: TokenInfoParameters,
+    ): Promise<TokenInfo | null> {
+        console.log("walletClient", walletClient);
+        const chainId = walletClient.getChain().id;
+        console.log(
+            `Searching for token: ${parameters.symbol} on chain: ${chainId}`,
+        );
+
+        // First check known tokens
+        const knownToken =
+            KNOWN_TOKENS[
+                parameters.symbol.toUpperCase() as keyof typeof KNOWN_TOKENS
+            ];
+        if (knownToken) {
+            console.log(`Found token in known tokens list: ${knownToken.name}`);
+            const chainData = knownToken.chains[chainId.toString()];
+            if (!chainData) {
+                console.log(
+                    `Token ${knownToken.symbol} not available on chain ${chainId}`,
+                );
+                return null; // Token not available on current network
+            }
+
+            console.log(`Returning known token data for ${knownToken.symbol}`);
+            return {
+                symbol: knownToken.symbol,
+                name: knownToken.name,
+                decimals: knownToken.decimals,
+                contractAddress: chainData.contractAddress,
+            };
+        }
+
+        console.log(`Token not found in known list, trying CoinGecko API...`);
+        // If not found, try CoinGecko
+        try {
+            const response = await fetch(
+                `${this.coingeckoBaseUrl}coins/list?include_platform=true`,
+                {
+                    method: "GET",
+                    headers: {
+                        accept: "application/json",
+                        "x-cg-demo-api-key": this.apiKey,
+                    },
+                },
+            );
+            const data: CoinGeckoToken[] = await response.json();
+
+            const matches = data.filter(
+                (token) =>
+                    token.symbol.toLowerCase() ===
+                    parameters.symbol.toLowerCase(),
+            );
+            console.log(`Found ${matches.length} matching tokens on CoinGecko`);
+            if (matches.length > 0) {
+                console.log(
+                    "Matching tokens:",
+                    matches.map((token) => ({
+                        name: token.name,
+                        symbol: token.symbol,
+                        platforms: token.platforms,
+                    })),
+                );
+            }
+            for (const token of matches) {
+                console.log(`Checking token: ${token.name}`);
+                const platformAddress = this.getPlatformAddressForChainId(
+                    token.platforms,
+                    chainId,
+                );
+
+                if (platformAddress) {
+                    console.log(
+                        `Found valid contract address for ${token.name}`,
+                    );
+                    const tokenDecimals = await walletClient.read({
+                        address: platformAddress as `0x${string}`,
+                        abi: ERC20_ABI,
+                        functionName: "decimals",
+                    });
+                    const tokenDecimalsParsed = (
+                        tokenDecimals as { value: number }
+                    ).value;
+                    return {
+                        symbol: token.symbol.toUpperCase(),
+                        name: token.name,
+                        contractAddress: platformAddress as `0x${string}`,
+                        decimals: tokenDecimalsParsed,
+                    };
+                }
+                console.log(
+                    `No valid contract address found for ${token.name} on chain ${chainId}`,
+                );
+            }
+
+            console.log(`No matching tokens found on CoinGecko`);
+            return null;
+        } catch (error) {
+            console.error(`CoinGecko API error:`, error);
+            return null;
+        }
+    }
+
+    private getPlatformAddressForChainId(
+        platforms: Record<string, string> | undefined,
+        chainId: number,
+    ): string | null {
+        if (!platforms) return null;
+
+        // Map chain IDs to CoinGecko platform identifiers
+        const platformMap: Record<number, string> = {
+            1: "ethereum",
+            137: "polygon-pos",
+            10: "optimistic-ethereum",
+            42161: "arbitrum-one",
+            8453: "base",
+            34443: "mode",
+            // Add more mappings as needed
+        };
+
+        const platformIdentifier = platformMap[chainId];
+        console.log(`Platform identifier: ${platformIdentifier}`);
+        if (!platformIdentifier) {
+            console.log(`No platform mapping found for chain ID ${chainId}`);
+            return null;
+        }
+
+        if (platforms[platformIdentifier]) {
+            console.log(
+                `Found contract address on platform ${platformIdentifier}: ${platforms[platformIdentifier]}`,
+            );
+            return platforms[platformIdentifier];
+        }
+
+        console.log(
+            `No contract address found for chain ${chainId} in platforms:`,
+            platforms,
+        );
+        return null;
+    }
+}

--- a/typescript/packages/plugins/token-info/src/token.ts
+++ b/typescript/packages/plugins/token-info/src/token.ts
@@ -1,0 +1,118 @@
+export type Token = {
+    decimals: number;
+    symbol: string;
+    name: string;
+    chains: Record<string, { contractAddress: `0x${string}` }>;
+};
+
+export type ChainSpecificToken = {
+    chainId: number;
+    decimals: number;
+    symbol: string;
+    name: string;
+    contractAddress: `0x${string}`;
+};
+
+const TOKENS: Record<string, Token> = {
+    PEPE: {
+        decimals: 18,
+        symbol: "PEPE",
+        name: "Pepe",
+        chains: {
+            "1": {
+                contractAddress: "0x6982508145454Ce325dDbE47a25d4ec3d2311933",
+            },
+            "10": {
+                contractAddress: "0xc1c167cc44f7923cd0062c4370df962f9ddb16f5",
+            },
+            "8453": {
+                contractAddress: "0xb4fde59a779991bfb6a52253b51947828b982be3",
+            },
+        },
+    },
+    USDC: {
+        decimals: 6,
+        symbol: "USDC",
+        name: "USDC",
+        chains: {
+            "1": {
+                contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            },
+            "10": {
+                contractAddress: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+            },
+            "137": {
+                contractAddress: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+            },
+            "8453": {
+                contractAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            },
+            "84532": {
+                contractAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            },
+            "11155111": {
+                contractAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+            },
+            "34443": {
+                contractAddress: "0xd988097fb8612cc24eeC14542bC03424c656005f",
+            },
+        },
+    },
+    MODE: {
+        decimals: 18,
+        symbol: "MODE",
+        name: "Mode",
+        chains: {
+            "34443": {
+                contractAddress: "0xDfc7C877a950e49D2610114102175A06C2e3167a",
+            },
+        },
+    },
+    WETH: {
+        decimals: 18,
+        symbol: "WETH",
+        name: "Wrapped Ether",
+        chains: {
+            "1": {
+                contractAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+            },
+            "8453": {
+                contractAddress: "0x4200000000000000000000000000000000000006",
+            },
+            "34443": {
+                contractAddress: "0x4200000000000000000000000000000000000006",
+            },
+            "42161": {
+                contractAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+            },
+            "10": {
+                contractAddress: "0x4200000000000000000000000000000000000006",
+            },
+            "137": {
+                contractAddress: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+            },
+        },
+    },
+} as const;
+
+export type TokenSymbol = keyof typeof TOKENS;
+export const KNOWN_TOKENS = TOKENS;
+
+export function getTokensForNetwork(chainId: number, tokens: Token[]): ChainSpecificToken[] {
+    const result: ChainSpecificToken[] = [];
+
+    for (const token of tokens) {
+        const chainData = token.chains[chainId];
+        if (chainData) {
+            result.push({
+                chainId: chainId,
+                decimals: token.decimals,
+                symbol: token.symbol,
+                name: token.name,
+                contractAddress: chainData.contractAddress,
+            });
+        }
+    }
+
+    return result;
+}

--- a/typescript/packages/plugins/token-info/src/types.ts
+++ b/typescript/packages/plugins/token-info/src/types.ts
@@ -1,0 +1,13 @@
+export interface CoinGeckoToken {
+    id: string;
+    symbol: string;
+    name: string;
+    platforms?: Record<string, string>;
+}
+
+export interface TokenInfo {
+    symbol: string;
+    name: string;
+    decimals?: number;
+    contractAddress: `0x${string}`;
+}

--- a/typescript/packages/plugins/token-info/tsconfig.json
+++ b/typescript/packages/plugins/token-info/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../../tsconfig.base.json",
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/plugins/token-info/tsup.config.ts
+++ b/typescript/packages/plugins/token-info/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { treeShakableConfig } from "../../../tsup.config.base";
+
+export default defineConfig({
+    ...treeShakableConfig,
+});

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -737,9 +737,6 @@ importers:
       '@goat-sdk/plugin-kim':
         specifier: workspace:*
         version: link:../../../packages/plugins/kim
-      '@goat-sdk/plugin-token-info':
-        specifier: workspace:*
-        version: link:../../../packages/plugins/token-info
       '@goat-sdk/wallet-evm':
         specifier: workspace:*
         version: link:../../../packages/wallets/evm

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -737,6 +737,9 @@ importers:
       '@goat-sdk/plugin-kim':
         specifier: workspace:*
         version: link:../../../packages/plugins/kim
+      '@goat-sdk/plugin-token-info':
+        specifier: workspace:*
+        version: link:../../../packages/plugins/token-info
       '@goat-sdk/wallet-evm':
         specifier: workspace:*
         version: link:../../../packages/wallets/evm
@@ -2007,6 +2010,21 @@ importers:
       '@solana/web3.js':
         specifier: 'catalog:'
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
+
+  packages/plugins/token-info:
+    dependencies:
+      '@goat-sdk/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@goat-sdk/wallet-evm':
+        specifier: workspace:*
+        version: link:../../wallets/evm
+      viem:
+        specifier: 'catalog:'
+        version: 2.21.49(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.23.8)
       zod:
         specifier: 'catalog:'
         version: 3.23.8
@@ -17192,7 +17210,7 @@ snapshots:
 
   '@coinbase/wallet-sdk@4.2.3':
     dependencies:
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       clsx: 1.2.1
       eventemitter3: 5.0.1
       preact: 10.25.4
@@ -17201,7 +17219,7 @@ snapshots:
 
   '@confio/ics23@0.6.8':
     dependencies:
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       protobufjs: 6.11.4
 
   '@coral-xyz/anchor-errors@0.30.1': {}
@@ -17358,7 +17376,7 @@ snapshots:
       '@cosmjs/encoding': 0.33.0
       '@cosmjs/math': 0.33.0
       '@cosmjs/utils': 0.33.0
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       bn.js: 5.2.1
       elliptic: 6.6.1
       libsodium-wrappers-sumo: 0.7.15
@@ -18725,7 +18743,7 @@ snapshots:
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.10.10)(terser@5.37.0))
       '@fuel-ts/versions': 0.97.2
       '@fuels/vm-asm': 0.58.2
-      '@noble/curves': 1.8.0
+      '@noble/curves': 1.8.1
       events: 3.3.0
       graphql: 16.10.0
       graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.10.0)
@@ -18741,7 +18759,7 @@ snapshots:
       '@fuel-ts/errors': 0.97.2
       '@fuel-ts/interfaces': 0.97.2
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.10.10)(terser@5.37.0))
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       bech32: 2.0.0
     transitivePeerDependencies:
       - vitest
@@ -18772,7 +18790,7 @@ snapshots:
       '@fuel-ts/interfaces': 0.97.2
       '@fuel-ts/math': 0.97.2
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.10.10)(terser@5.37.0))
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
 
@@ -18785,7 +18803,7 @@ snapshots:
       '@fuel-ts/crypto': 0.97.2(vitest@2.1.9(@types/node@22.10.10)(terser@5.37.0))
       '@fuel-ts/interfaces': 0.97.2
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.10.10)(terser@5.37.0))
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - vitest
 
@@ -18974,14 +18992,14 @@ snapshots:
   '@hpke/dhkem-x25519@1.6.1':
     dependencies:
       '@hpke/common': 1.7.1
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
 
   '@hpke/dhkem-x448@1.6.1':
     dependencies:
       '@hpke/common': 1.7.1
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
 
   '@huggingface/inference@2.8.1':
     dependencies:
@@ -20639,7 +20657,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.1.0
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       '@scure/base': 1.2.1
       '@types/debug': 4.1.12
       debug: 4.4.0
@@ -20653,7 +20671,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.1.0
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       '@scure/base': 1.2.1
       '@types/debug': 4.1.12
       debug: 4.4.0
@@ -20713,7 +20731,7 @@ snapshots:
     dependencies:
       '@metaplex-foundation/umi': 0.9.2
       '@metaplex-foundation/umi-web3js-adapters': 0.9.2(@metaplex-foundation/umi@0.9.2)(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
-      '@noble/curves': 1.8.0
+      '@noble/curves': 1.8.1
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
 
   '@metaplex-foundation/umi-http-fetch@0.9.2(@metaplex-foundation/umi@0.9.2)(encoding@0.1.13)':
@@ -21533,7 +21551,7 @@ snapshots:
       '@safe-global/types-kit': 1.0.2(typescript@5.6.3)(zod@3.24.1)
       abitype: 1.0.8(typescript@5.6.3)(zod@3.24.1)
       semver: 7.6.3
-      viem: 2.21.49(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      viem: 2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     optionalDependencies:
       '@noble/curves': 1.8.0
       '@peculiar/asn1-schema': 2.3.15
@@ -21552,7 +21570,7 @@ snapshots:
       semver: 7.6.3
       viem: 2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     optionalDependencies:
-      '@noble/curves': 1.8.0
+      '@noble/curves': 1.8.1
       '@peculiar/asn1-schema': 2.3.15
     transitivePeerDependencies:
       - bufferutil
@@ -21634,7 +21652,7 @@ snapshots:
       '@safe-global/protocol-kit': 5.2.2(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@safe-global/relay-kit': 3.4.3(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@safe-global/types-kit': 1.0.2(typescript@5.6.3)(zod@3.24.1)
-      viem: 2.21.49(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      viem: 2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21680,8 +21698,8 @@ snapshots:
 
   '@scure/bip32@1.6.1':
     dependencies:
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
       '@scure/base': 1.2.1
 
   '@scure/bip32@1.6.2':
@@ -21707,7 +21725,7 @@ snapshots:
 
   '@scure/bip39@1.5.1':
     dependencies:
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       '@scure/base': 1.2.1
 
   '@scure/bip39@1.5.4':
@@ -22713,7 +22731,7 @@ snapshots:
 
   '@spruceid/siwe-parser@2.1.2':
     dependencies:
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       apg-js: 4.4.0
       uri-js: 4.4.1
       valid-url: 1.0.9
@@ -22886,7 +22904,7 @@ snapshots:
 
   '@turnkey/api-key-stamper@0.4.3':
     dependencies:
-      '@noble/curves': 1.8.0
+      '@noble/curves': 1.8.1
       '@turnkey/encoding': 0.4.0
       sha256-uint8array: 0.10.7
 
@@ -25019,7 +25037,7 @@ snapshots:
 
   bs58check@3.0.1:
     dependencies:
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
       bs58: 5.0.0
 
   bser@2.1.1:
@@ -25856,8 +25874,8 @@ snapshots:
     dependencies:
       '@ecies/ciphers': 0.2.2(@noble/ciphers@1.2.0)
       '@noble/ciphers': 1.2.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
 
   ee-first@1.1.1: {}
 
@@ -26197,7 +26215,7 @@ snapshots:
 
   ethereum-bloom-filters@1.2.0:
     dependencies:
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
 
   ethereum-cryptography@0.1.3:
     dependencies:
@@ -27207,7 +27225,7 @@ snapshots:
       '@hpke/core': 1.7.1
       '@hpke/dhkem-x25519': 1.6.1
       '@hpke/dhkem-x448': 1.6.1
-      '@noble/hashes': 1.7.0
+      '@noble/hashes': 1.7.1
 
   html-escaper@2.0.2: {}
 
@@ -29253,10 +29271,10 @@ snapshots:
   ox@0.1.2(typescript@5.6.3)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
-      '@scure/bip32': 1.6.1
-      '@scure/bip39': 1.5.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.6.3)(zod@3.23.8)
       eventemitter3: 5.0.1
     optionalDependencies:
@@ -29267,10 +29285,10 @@ snapshots:
   ox@0.1.2(typescript@5.6.3)(zod@3.24.1):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
-      '@scure/bip32': 1.6.1
-      '@scure/bip39': 1.5.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.6.3)(zod@3.24.1)
       eventemitter3: 5.0.1
     optionalDependencies:
@@ -29281,10 +29299,10 @@ snapshots:
   ox@0.6.5(typescript@5.6.3)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
-      '@scure/bip32': 1.6.1
-      '@scure/bip39': 1.5.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.6.3)(zod@3.23.8)
       eventemitter3: 5.0.1
     optionalDependencies:
@@ -32415,13 +32433,13 @@ snapshots:
 
   webauthn-p256@0.0.10:
     dependencies:
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
 
   webauthn-p256@0.0.5:
     dependencies:
-      '@noble/curves': 1.8.0
-      '@noble/hashes': 1.7.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
 
   webextension-polyfill@0.10.0: {}
 


### PR DESCRIPTION
# Background

This PR adds a better way of finding fetching token details using a mix of tokens stored in the plugin and the coingecko API

# Testing
## Detailed testing results
| Method | Prompt | Screenshot | Transaction Link |
|----------|--------|-------|------------------|
| Getting a token that's stored in the token file | Can you give me token info on USDC | <img width="1034" alt="Screenshot 2025-02-25 at 2 51 34 PM" src="https://github.com/user-attachments/assets/7c4d8f1a-ac0c-48b0-9d89-1de90c019dff" /> | N/A |
| Getting a token that needs to be fetched from CoinGecko | can you give me token info on ezETH | <img width="1024" alt="Screenshot 2025-02-25 at 2 51 23 PM" src="https://github.com/user-attachments/assets/36c26c90-304a-4d98-8acc-7da94f49017b" />| N/A |

## For plugins
- [x] I have tested this change locally with key pair wallets
- [x] I have tested this change locally with hosted wallets (e.g. Crossmint Smart Wallets, etc.)
- [x] Package exists in the [goat workspace file](https://github.com/goat-sdk/goat/blob/main/goat.code-workspace)

## Discord username
sunosuporno