### PR TITLE
fix(orderly-network): streamline order creation logic and improve parameter handling

### DIFF
--- a/typescript/packages/plugins/orderly-network/src/orderly-network.service.ts
+++ b/typescript/packages/plugins/orderly-network/src/orderly-network.service.ts
@@ -167,15 +167,11 @@ export class OrderlyNetworkService {
 
         if (convertedOrderType === OrderType.MARKET) {
             parameters.order_price = undefined;
-        }
-
-        if (convertedOrderType === OrderType.MARKET && parameters.side === "BUY") {
-            if (parameters.order_amount !== undefined) {
-                throw new Error(
-                    "In Futures mode, BUY orders do not support order_amount. Please use order_quantity instead.",
-                );
+            if (parameters.side === "BUY") {
+                parameters.order_amount = undefined;
             }
         }
+
         const order = {
             ...parameters,
             order_type: convertedOrderType,
@@ -260,7 +256,7 @@ export class OrderlyNetworkService {
         };
 
         const allowedSymbol =
-            symbols.data.rows.find(({ symbol }) => symbol.includes(`_${parameters.token}_`))?.symbol ??
+            symbols.data.rows.find(({ symbol }) => symbol.includes(`_${parameters.token.toUpperCase()}_`))?.symbol ??
             symbols.data.rows[0].symbol;
         return allowedSymbol;
     }


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

<!-- LINK TO ISSUE OR TICKET -->

# Background

## What does this PR do?
- The createOrderOrderly function has been updated to avoid the error when opening market orders in Futures mode. Now, for MARKET orders, order_price is set to undefined, and for BUY orders, order_amount is discarded (set to undefined) so that only the base unit value is used.
- The allowed symbol lookup logic was adjusted by using parameters.token.toUpperCase() in the comparison, ensuring that the search is case-insensitive.


# Testing
<!-- Steps for the reviewer to test these changes -->
1. Run an example that attempts to create a market BUY order in Futures mode.
2. Verify that the order is processed without the error "In Futures mode, BUY orders do not support order_amount".
3. Confirm that the allowed symbol lookup works correctly by converting the token to uppercase.


## Detailed testing results
<!-- 
Show that you've tested each function on your plugin/adapter/wallet. To do so simply:
1. Go to the examples directory and choose an example to test with
2. Import your plugin/wallet/adapter
3. Test each action and fill the table below with a screenshot and an example transaction showing that your changes worked
4. Don't push any changes to the example dir
-->

| Method | Prompt | Screenshot | Transaction Link |
|----------|--------|-------|------------------|
| create_order_orderly| can you open a market order for btc? I want to long  it with 20x leverage and 20usdc  position size | ![image](https://github.com/user-attachments/assets/33fed203-21ae-4dc3-81d5-e9a54ce03b85) | n/a |
| get_allowed_symbol_by_network | Get allowed symbol by network mainnet and btc | <img width="611" alt="image" src="https://github.com/user-attachments/assets/7f0dfcab-07c3-4cf9-a880-ed97501c2ce1" /> | n/a |


# Docs
<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->

## Checklist
- [x] I have tested this change and added the relevant screenshots to the PR description
- [ ] I updated the [README](https://github.com/goat-sdk/goat/blob/main/README.md) if necessary to include the new plugin, wallet, chain, etc.

If you require releasing a new version of the package:
- [ ] I have added a changset for the specific package by running `pnpm change:add` from the `typescript` directory
