### PR TITLE
feat: add removeLiquidity function for ERC20/ERC20 LPs in Velodrome

### DIFF
--- a/typescript/packages/plugins/velodrome/src/parameters.ts
+++ b/typescript/packages/plugins/velodrome/src/parameters.ts
@@ -40,3 +40,21 @@ export class AddLiquidityParams extends createToolParameters(
             .describe("The deadline for the transaction in seconds from now"),
     }),
 ) {}
+
+export class removeLiquidityParams extends createToolParameters(
+    z.object({
+        token0: z.string().describe("Address of the first token"),
+        token1: z.string().describe("Address of the second token"),
+        stable: z.boolean().describe("Whether the pool is stable or volatile"),
+        amount: z.string().optional().describe("Amount to remove (e.g., 'half', 'all')"),
+        liquidity: z.string().optional().describe("Specific amount of LP tokens to remove"),
+        amountAMin: z.string().optional().describe("Minimum amount of token0 to receive"),
+        amountBMin: z.string().optional().describe("Minimum amount of token1 to receive"),
+        to: z.string().optional().describe("Address to receive tokens, defaults to sender"),
+        deadline: z
+            .number()
+            .optional()
+            .default(() => Math.floor(Date.now() / 1000) + 3600)
+            .describe("Deadline for the transaction in seconds"),
+    }),
+) { }

--- a/typescript/packages/plugins/velodrome/src/velodrome.service.ts
+++ b/typescript/packages/plugins/velodrome/src/velodrome.service.ts
@@ -418,7 +418,256 @@ export class VelodromeService {
         const amount0Optimal = (amount1Desired * reserve0) / reserve1;
         return [amount0Optimal, amount1Desired];
     }
+@Tool({
+        name: "remove_liquidity",
+        description: "remove liquidity to a Velodrome pool.",
+    })
+    async removeLiquidity(walletClient: EVMWalletClient, parameters: removeLiquidityParams) {
+        try {
+
+            const userAddress = walletClient.getAddress();
+
+            const chain = walletClient.getChain();
+            if (!chain) {
+                throw new Error("Chain not configured in wallet client");
+            }
+
+            const routerAddress = ROUTER_ADDRESS[chain.id];
+            if (!routerAddress) {
+                throw new Error(`Router not found for chain ${chain.id}`);
+            }
+
+            // Get tokens in correct order
+            const [token0, token1] = await this.sortTokens(walletClient, parameters.token0, parameters.token1);
+
+            // Get pool address
+            const poolContract = await this.getPool(walletClient, token0, token1, parameters.stable);
+
+            let poolAddress: string;
+            if (typeof poolContract === 'object' && poolContract !== null) {
+                const poolObj = poolContract as any;
+                if ('value' in poolObj && typeof poolObj.value === 'string') {
+                    poolAddress = poolObj.value;
+                } else if ('address' in poolObj && typeof poolObj.address === 'string') {
+                    poolAddress = poolObj.address;
+                } else {
+                    console.error('Pool contract is an object but does not have expected properties:',
+                        JSON.stringify(poolContract, null, 2));
+                    throw new Error("Could not extract pool address from pool contract");
+                }
+            } else if (typeof poolContract === 'string') {
+                poolAddress = poolContract;
+            } else {
+                console.error('Unexpected pool contract value:', poolContract);
+                throw new Error("Pool address is not in a valid format");
+            }
+
+            // Get LP token balance for this pool
+            let lpTokenBalanceRaw;
+            try {
+                lpTokenBalanceRaw = await walletClient.read({
+                    address: poolAddress as Address,
+                    abi: erc20Abi,
+                    functionName: "balanceOf",
+                    args: [userAddress]
+                });
+            } catch (error) {
+                console.error("Error reading LP token balance:", error);
+                return { error: `Failed to read LP token balance: ${String(error)}` };
+            }
+
+            let lpTokenBalance: string;
+            try {
+                if (lpTokenBalanceRaw === null || lpTokenBalanceRaw === undefined) {
+                    lpTokenBalance = '0';
+                } else if (typeof lpTokenBalanceRaw === 'bigint') {
+                    lpTokenBalance = (lpTokenBalanceRaw as number).toString();
+                } else if (typeof lpTokenBalanceRaw === 'number') {
+                    lpTokenBalance = (lpTokenBalanceRaw as number).toString();
+                } else if (typeof lpTokenBalanceRaw === 'string') {
+                    // Ensure it's a numeric string
+                    if (/^\d+$/.test(lpTokenBalanceRaw)) {
+                        lpTokenBalance = lpTokenBalanceRaw;
+                    } else {
+                        console.error("LP token balance is not a numeric string:", lpTokenBalanceRaw);
+                        lpTokenBalance = '0';
+                    }
+                } else if (typeof lpTokenBalanceRaw === 'object' && lpTokenBalanceRaw !== null) {
+                    if ('toString' in lpTokenBalanceRaw && typeof lpTokenBalanceRaw.toString === 'function') {
+                        const stringVal = lpTokenBalanceRaw.toString();
+                        if (/^\d+$/.test(stringVal)) {
+                            lpTokenBalance = stringVal;
+                        } else {
+                            if ('value' in lpTokenBalanceRaw && lpTokenBalanceRaw.value !== undefined) {
+                                const valueStr = String(lpTokenBalanceRaw.value);
+                                if (/^\d+$/.test(valueStr)) {
+                                    lpTokenBalance = valueStr;
+                                } else {
+                                    lpTokenBalance = '0';
+                                }
+                            } else {
+                                lpTokenBalance = '0';
+                            }
+                        }
+                    } else if ('value' in lpTokenBalanceRaw && lpTokenBalanceRaw.value !== undefined) {
+                        const valueStr = String(lpTokenBalanceRaw.value);
+                        if (/^\d+$/.test(valueStr)) {
+                            lpTokenBalance = valueStr;
+                        } else {
+                            lpTokenBalance = '0';
+                        }
+                    } else {
+                        lpTokenBalance = '0';
+                    }
+                } else {
+                    console.error("Unexpected LP token balance type:", typeof lpTokenBalanceRaw);
+                    lpTokenBalance = '0';
+                }
+            } catch (error) {
+                console.error("Error processing LP token balance:", error);
+                lpTokenBalance = '0';
+            }
+
+            if (!/^\d+$/.test(lpTokenBalance) || lpTokenBalance === '0') {
+                if (lpTokenBalance === '0') {
+                    return { error: "You don't have any LP tokens in this pool" };
+                } else {
+                    return { error: `Invalid LP token balance: ${lpTokenBalance}` };
+                }
+            }
+
+            // Calculate the amount to withdraw
+            let liquidityToRemove: string;
+            let percentToRemove = 1.0; // Default to 100%
+
+            try {
+                // Handle the 'amount' parameter (as text)
+                if (parameters.amount) {
+                    const amountText = String(parameters.amount).toLowerCase();
+
+                    if (amountText.includes('half') || amountText.includes('50%')) {
+                        percentToRemove = 0.5;
+                        const halfAmount = BigInt(lpTokenBalance) * BigInt(50) / BigInt(100);
+                        liquidityToRemove = halfAmount.toString();
+                    } else if (amountText.includes('quarter') || amountText.includes('25%')) {
+                        percentToRemove = 0.25;
+                        const quarterAmount = BigInt(lpTokenBalance) * BigInt(25) / BigInt(100);
+                        liquidityToRemove = quarterAmount.toString();
+                    } else if (amountText.includes('all') || amountText.includes('100%') || amountText === 'all') {
+                        percentToRemove = 1.0;
+                        liquidityToRemove = lpTokenBalance;
+                    } else {
+                        // If it's a specific numeric value
+                        const parsedAmount = parseInt(amountText);
+                        if (!isNaN(parsedAmount)) {
+                            liquidityToRemove = parsedAmount.toString();
+                        } else {
+                            // If it can't be parsed, use the entire balance
+                            liquidityToRemove = lpTokenBalance;
+                        }
+                    }
+                } else if (parameters.liquidity) {
+                    const liquidityParam = String(parameters.liquidity);
+                    if (liquidityParam.toLowerCase() === 'all') {
+                        liquidityToRemove = lpTokenBalance;
+                    } else {
+                        if (/^\d+$/.test(liquidityParam)) {
+                            liquidityToRemove = liquidityParam;
+                        } else {
+                            liquidityToRemove = lpTokenBalance;
+                        }
+                    }
+                } else {
+                    liquidityToRemove = lpTokenBalance;
+                }
+
+                if (!/^\d+$/.test(liquidityToRemove)) {
+                    console.error(`liquidityToRemove is not a valid number: ${liquidityToRemove}`);
+                    return { error: `Invalid liquidity amount: ${liquidityToRemove}` };
+                }
+
+                // Validate there is enough liquidity to withdraw
+                if (BigInt(liquidityToRemove) <= BigInt(0)) {
+                    return { error: "No liquidity to remove" };
+                }
+            } catch (error) {
+                console.error("Error calculating liquidity to remove:", error);
+                return { error: `Failed to calculate removal amount: ${String(error)}` };
+            }
+
+            // Approve LP tokens to the router
+            try {
+                const approvalHash = await walletClient.sendTransaction({
+                    to: poolAddress as Address,
+                    abi: erc20Abi,
+                    functionName: "approve",
+                    args: [routerAddress as Address, liquidityToRemove]
+                });
+            } catch (approvalError) {
+                console.error("Approval error details:", approvalError);
+                return {
+                    error: `Approval failed: ${String(approvalError)}`,
+                    details: { approvalError }
+                };
+            }
+
+            // Calculate deadline
+            const deadline = parameters.deadline || 1800; // Default to 30 minutes
+            const timestamp = Math.floor(Date.now() / 1000) + deadline;
+
+            // Set amountAMin and amountBMin if not defined
+            const amountAMin = parameters.amountAMin || "0";
+            const amountBMin = parameters.amountBMin || "0";
+
+            try {
+
+                const removeTx = await walletClient.sendTransaction({
+                    to: routerAddress as Address,
+                    abi: ROUTER_ABI,
+                    functionName: "removeLiquidity",
+                    args: [
+                        token0,
+                        token1,
+                        parameters.stable,
+                        liquidityToRemove,
+                        amountAMin,
+                        amountBMin,
+                        parameters.to || userAddress,
+                        timestamp
+                    ]
+                });
+
+                const txHash = removeTx.hash || (typeof removeTx === 'string' ? removeTx : 'unknown');
+
+
+                return {
+                    success: true,
+                    transactionHash: txHash,
+                    liquidityRemoved: liquidityToRemove,
+                    percentage: `${percentToRemove * 100}%`,
+                    tokens: {
+                        token0,
+                        token1
+                    }
+                };
+            } catch (txError) {
+                console.error("Transaction error details:", txError);
+                return {
+                    error: `Transaction failed: ${String(txError)}`,
+                    approvalSuccess: true,
+                    details: { txError }
+                };
+            }
+        } catch (error) {
+            console.error("Error in removeLiquidity:", error);
+            return {
+                error: String(error),
+                details: { error }
+            };
+        }
+    }
 }
+
 
 type Token = {
     decimals: number;


### PR DESCRIPTION
# Background

## What does this PR do?

This PR adds support for removing liquidity from ERC20/ERC20 LPs in the Velodrome plugin.

Changes:
- Added new `removeLiquidity` function in `velodrome.service.ts`.
- Defined the required parameters in `parameters.ts`.

Note: This function does not handle ETH LPs. It is specific to ERC20/ERC20 pools.

# Testing

To test the plugin, run it from: `typescript/examples/by-use-case/evm-defi-agent`

## Detailed testing results


| Method | Prompt | Screenshot | Transaction Link |
|----------|--------|-------|------------------|
| removeLiquidity | Remove all of my liquidity from the volatile USDC MODE pool using velodrome. | ![removeLiquidity1](https://github.com/user-attachments/assets/14613378-3ae1-4d49-8209-28b530f4b81c) | [Transaction link](https://explorer.mode.network/tx/0x686026e08d9833980ee49ebb39bbd0bf49f2f5f6685fdd03708a27d5a8b96c39) |
| removeLiquidity | Remove 50% of my liquidity from the volatile USDC MODE pool using velodrome. | ![removeLiquidity2](https://github.com/user-attachments/assets/70200c35-2943-48f4-a7f2-d99a292993ac) | [Transaction link](https://explorer.mode.network/tx/0xc891af9facb565b76c8aeb2bfad2f27d819a78eb3f49a9b635e3ed50a7f489a6) |


# Docs
<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->

## Checklist
- [x] I have tested this change and added the relevant screenshots to the PR description
- [ ] I updated the [README](https://github.com/goat-sdk/goat/blob/main/README.md) if necessary to include the new plugin, wallet, chain, etc.

If you require releasing a new version of the package:
- [ ] I have added a changset for the specific package by running `pnpm change:add` from the `typescript` directory
