### PR TITLE
Fix(plugin-polymarket): Handle optional outcomePrices in get_events response

### DIFF
--- a/typescript/packages/plugins/polymarket/src/api.ts
+++ b/typescript/packages/plugins/polymarket/src/api.ts
@@ -75,7 +75,7 @@ const Event = z.object({
             oneDayPriceChange: z.number().optional(),
             orderMinSize: z.number(),
             orderPriceMinTickSize: z.number(),
-            outcomePrices: z.string(),
+            outcomePrices: z.string().optional(),
             outcomes: z.string(),
             question: z.string().optional(),
             slug: z.string(),


### PR DESCRIPTION
## Problem

The `get_polymarket_events` tool (and underlying API function) was failing due to two issues related to the `outcomePrices` field returned by the Polymarket API:

1.  **Zod Validation Error:** The internal `Event` schema in `api.ts` defined `outcomePrices` as a required `string`. However, the Polymarket API sometimes omits this field, causing a Zod validation error (`"Required"`).
2.  **JSON Parse Error:** The `transformMarketOutcomes` helper function in `utils.ts` unconditionally called `JSON.parse()` on `outcomePrices`. When the field was missing (and thus `undefined` after the schema change), this resulted in a `JSON Parse error: Unexpected identifier "undefined"`.

## Solution

This PR addresses both issues:

1.  **Schema Update (`api.ts`):** Marks `outcomePrices` as `.optional()` in the `Event` Zod schema to correctly reflect the Polymarket API behavior.
2.  **Helper Function Update (`utils.ts`):** Modifies `transformMarketOutcomes` to:
    *   Check if `market.outcomePrices` is a non-empty string before attempting `JSON.parse()`.
    *   Default to an empty array (`[]`) if parsing fails or the input is not a valid string, ensuring the subsequent `.map()` call doesn't fail.

These changes ensure the `get_polymarket_events` function handles responses gracefully, whether `outcomePrices` is present or not.