### PR TITLE
feat: Lulo USDC withdraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 <div>
   <img src="https://github.com/user-attachments/assets/59fa5ddc-9d47-4d41-a51a-64f6798f94bd" alt="GOAT" width="100%" height="auto" style="object-fit: contain; max-width: 800px;">
 
@@ -165,7 +163,7 @@ GOAT is free software, MIT licensed.
 | JSON RPC | Call any JSON RPC endpoint |[@goat-sdk/plugin-jsonrpc](https://www.npmjs.com/package/@goat-sdk/plugin-jsonrpc) | [goat-sdk-plugin-jsonrpc](https://github.com/goat-sdk/goat/tree/main/python/src/plugins/jsonrpc) |
 | Jupiter | Swap tokens on Jupiter | [@goat-sdk/plugin-jupiter](https://www.npmjs.com/package/@goat-sdk/plugin-jupiter) | [goat-sdk-plugin-jupiter](https://github.com/goat-sdk/goat/tree/main/python/src/plugins/jupiter) |
 | KIM | Swap tokens on KIM | [@goat-sdk/plugin-kim](https://www.npmjs.com/package/@goat-sdk/plugin-kim) |
-| Lulo | Deposit USDC on Lulo | [@goat-sdk/plugin-lulo](https://www.npmjs.com/package/@goat-sdk/plugin-lulo) |
+| Lulo | Deposit and Withdraw USDC on Lulo | [@goat-sdk/plugin-lulo](https://www.npmjs.com/package/@goat-sdk/plugin-lulo) |
 | Mayan | Cross-chain token swap using Mayan SDK (Solana, EVM, SUI) | [@goat-sdk/plugin-mayan](https://www.npmjs.com/package/@goat-sdk/plugin-mayan) |
 | Meteora | Create liquidity pools on Meteora | [@goat-sdk/plugin-meteora](https://www.npmjs.com/package/@goat-sdk/plugin-meteora) |
 | Mode Governance | Create a governance proposal on Mode | [@goat-sdk/plugin-mode-governance](https://www.npmjs.com/package/@goat-sdk/plugin-mode-governance) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "goat-repo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goat-repo",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "husky": "^9.1.7"
+      },
+      "engines": {
+        "node": ">=20.12.2",
+        "npm": "please-use-pnpm",
+        "pnpm": ">=9",
+        "yarn": "please-use-pnpm"
+      }
+    },
+    "node_modules/.pnpm/husky@9.1.7/node_modules/husky": {
+      "version": "9.1.7",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/husky": {
+      "resolved": "node_modules/.pnpm/husky@9.1.7/node_modules/husky",
+      "link": true
+    }
+  }
+}

--- a/typescript/.changeset/twenty-penguins-invent.md
+++ b/typescript/.changeset/twenty-penguins-invent.md
@@ -1,5 +1,5 @@
 ---
-"@goat-sdk/plugin-lulo": minor
+"@goat-sdk/plugin-lulo": patch
 ---
 
 Add USDC withdrawal functionality to Lulo plugin

--- a/typescript/.changeset/twenty-penguins-invent.md
+++ b/typescript/.changeset/twenty-penguins-invent.md
@@ -1,0 +1,5 @@
+---
+"@goat-sdk/plugin-lulo": minor
+---
+
+Add USDC withdrawal functionality to Lulo plugin

--- a/typescript/packages/plugins/lulo/README.md
+++ b/typescript/packages/plugins/lulo/README.md
@@ -33,7 +33,7 @@ const tools = await getOnChainTools({
 
 ## Tools
 - Deposit USDC
-- Withdraw any supported token by ticker or mint address
+- Withdraw USDC
 
 <footer>
 <br/>

--- a/typescript/packages/plugins/lulo/README.md
+++ b/typescript/packages/plugins/lulo/README.md
@@ -7,7 +7,7 @@
 
 # Lulo GOAT Plugin
 
-Deposit USDC on [Lulo](https://lulo.xyz/).
+Deposit USDC on [Lulo](https://lulo.fi/).
 
 ## Installation
 
@@ -33,6 +33,7 @@ const tools = await getOnChainTools({
 
 ## Tools
 - Deposit USDC
+- Withdraw any supported token by ticker or mint address
 
 <footer>
 <br/>

--- a/typescript/packages/plugins/lulo/README.md
+++ b/typescript/packages/plugins/lulo/README.md
@@ -7,7 +7,7 @@
 
 # Lulo GOAT Plugin
 
-Deposit USDC on [Lulo](https://lulo.fi/).
+Deposit and withdraw USDC on [Lulo](https://lulo.fi/).
 
 ## Installation
 

--- a/typescript/packages/plugins/lulo/src/lulo.service.ts
+++ b/typescript/packages/plugins/lulo/src/lulo.service.ts
@@ -1,6 +1,6 @@
 import { Tool } from "@goat-sdk/core";
 import { SolanaWalletClient } from "@goat-sdk/wallet-solana";
-import { DepositUSDCParameters } from "./parameters";
+import { DepositUSDCParameters, WithdrawTokenParameters } from "./parameters";
 
 export class LuloService {
     @Tool({
@@ -9,6 +9,28 @@ export class LuloService {
     })
     async depositUSDC(walletClient: SolanaWalletClient, parameters: DepositUSDCParameters) {
         const response = await fetch(`https://blink.lulo.fi/actions?amount=${parameters.amount}&symbol=USDC`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                account: walletClient.getAddress(),
+            }),
+        });
+
+        const data = await response.json();
+
+        const tx = await walletClient.sendRawTransaction(data.transaction);
+
+        return tx.hash;
+    }
+
+    @Tool({
+        name: "lulo_withdraw_usdc",
+        description: "Withdraw USDC from Lulo",
+    })
+    async withdrawUSDC(walletClient: SolanaWalletClient, parameters: WithdrawTokenParameters) {
+        const response = await fetch(`https://lulo.dial.to/api/actions/withdraw/usdc/${parameters.amount}`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/typescript/packages/plugins/lulo/src/parameters.ts
+++ b/typescript/packages/plugins/lulo/src/parameters.ts
@@ -5,10 +5,10 @@ export class DepositUSDCParameters extends createToolParameters(
     z.object({
         amount: z.string().describe("Amount of USDC to deposit"),
     }),
-) { }
+) {}
 
 export class WithdrawTokenParameters extends createToolParameters(
     z.object({
         amount: z.string().describe("Amount of USDC to withdraw"),
     }),
-) { }
+) {}

--- a/typescript/packages/plugins/lulo/src/parameters.ts
+++ b/typescript/packages/plugins/lulo/src/parameters.ts
@@ -5,4 +5,10 @@ export class DepositUSDCParameters extends createToolParameters(
     z.object({
         amount: z.string().describe("Amount of USDC to deposit"),
     }),
-) {}
+) { }
+
+export class WithdrawTokenParameters extends createToolParameters(
+    z.object({
+        amount: z.string().describe("Amount of USDC to withdraw"),
+    }),
+) { }


### PR DESCRIPTION
# Relates to:
<!-- LINK TO ISSUE OR TICKET -->
Adds withdraw USDC functionality to the Lulo plugin

# Background
The Lulo plugin currently only supported deposits. This PR adds the ability to withdraw USDC from Lulo as well, which completes the basic DeFi functionality for the plugin.

## What does this PR do?
1. Adds a new `withdrawUSDC` method to the Lulo service
2. Creates a `WithdrawTokenParameters` class with amount and token parameters
3. Registers the withdrawal function as a tool with the GOAT framework

# Testing
1. Install the examples/by-use-case/solana-usdc-yield-deposit example
2. Link the local version of the Lulo plugin: `"@goat-sdk/plugin-lulo": "file:../../../packages/plugins/lulo"`
3. Run the example and test both deposit and withdrawal functionality

## Detailed testing results

| Method | Prompt | Screenshot | Transaction Link |
|----------|--------|-------|------------------|
| lulo_withdraw_usdc | "withdraw 5 usdc from lulo" | ![Withdraw Screenshot](https://github.com/user-attachments/assets/23666299-8a3a-4fa5-84c3-7015b791b940) | [3uLiRN4RC7TyxtpSQzeJ5S6ij7St74a6XYNJVeGicjUsf5enBsKFEMe8qGJEJiWdK6bQQn646J12ta9mJTJfJmYn](https://solscan.io/tx/3uLiRN4RC7TyxtpSQzeJ5S6ij7St74a6XYNJVeGicjUsf5enBsKFEMe8qGJEJiWdK6bQQn646J12ta9mJTJfJmYn) |

# Docs
<!-- My changes do not require a change to the project documentation. -->
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.

## Checklist
- [x] I have tested this change and added the relevant screenshots to the PR description
- [x] I updated the [README](https://github.com/goat-sdk/goat/blob/main/README.md) to include the new withdrawal functionality in the Lulo plugin

If you require releasing a new version of the package:
- [x] I have added a changset for the specific package by running `pnpm change:add` from the `typescript` directory
