### PR TITLE
feat(EVMWalletClient): new method switchChain

### DIFF
--- a/typescript/.changeset/lemon-snails-poke.md
+++ b/typescript/.changeset/lemon-snails-poke.md
@@ -1,0 +1,8 @@
+---
+"@goat-sdk/wallet-lit": minor
+"@goat-sdk/wallet-safe": minor
+"@goat-sdk/wallet-viem": minor
+"@goat-sdk/wallet-evm": minor
+---
+
+new method "switchChain"

--- a/typescript/packages/wallets/crossmint/src/wallets/SmartWalletClient.ts
+++ b/typescript/packages/wallets/crossmint/src/wallets/SmartWalletClient.ts
@@ -279,6 +279,10 @@ export class SmartWalletClient extends EVMSmartWalletClient {
         return BigInt(balance);
     }
 
+    async switchChain(chainId: number) {
+        throw new Error("SmartWalletClient does not implement switchChain");
+    }
+
     private async _sendBatchOfTransactions(transactions: EVMTransaction[]) {
         const transactionDatas = transactions.map((transaction) => {
             const { to: recipientAddress, abi, functionName, args, value, data } = transaction;

--- a/typescript/packages/wallets/evm/src/EVMWalletClient.ts
+++ b/typescript/packages/wallets/evm/src/EVMWalletClient.ts
@@ -461,4 +461,5 @@ export abstract class EVMWalletClient extends WalletClientBase {
 
         return [...baseTools, ...commonEvmTools, ...sendingEvmTools];
     }
+    abstract switchChain(chainId: number): Promise<void>;
 }

--- a/typescript/packages/wallets/lit-protocol/src/evm.ts
+++ b/typescript/packages/wallets/lit-protocol/src/evm.ts
@@ -167,6 +167,10 @@ export class LitEVMWalletClient extends EVMWalletClient {
 
         return BigInt(balance);
     }
+
+    async switchChain(chainId: number) {
+        await this.viemPublicClient.switchChain({ id: chainId });
+    }
 }
 
 export function createEVMWallet(options: LitEVMWalletOptions) {

--- a/typescript/packages/wallets/safe/src/SafeWalletClient.ts
+++ b/typescript/packages/wallets/safe/src/SafeWalletClient.ts
@@ -266,6 +266,10 @@ export class SafeWalletClient extends EVMSmartWalletClient {
         };
     }
 
+    async switchChain(chainId: number) {
+        await this.#client.switchChain({ id: chainId });
+    }
+
     async isDeployed() {
         if (!this.#safeAccount) throw new Error("Safe account not initialized");
         if (!this.#safeAddress) throw new Error("Safe address not initialized");

--- a/typescript/packages/wallets/viem/src/ViemEVMWalletClient.ts
+++ b/typescript/packages/wallets/viem/src/ViemEVMWalletClient.ts
@@ -194,6 +194,10 @@ export class ViemEVMWalletClient extends EVMWalletClient {
         return { value: result };
     }
 
+    async switchChain(chainId: number) {
+        await this.#client.switchChain({ id: chainId });
+    }
+
     private async waitForReceipt(txHash: `0x${string}`): Promise<{ hash: string; status: "success" | "reverted" }> {
         const receipt = await this.publicClient.waitForTransactionReceipt({
             hash: txHash,


### PR DESCRIPTION

# Relates to:

#301

# Background

## What does this PR do?

Adds the ability to switch chains on the wallet

## Checklist
- [x] I have tested this change and added the relevant screenshots to the PR description
- [x] I updated the [README](https://github.com/goat-sdk/goat/blob/main/README.md) if necessary to include the new plugin, wallet, chain, etc.

If you require releasing a new version of the package:
- [x] I have added a changset for the specific package by running `pnpm change:add` from the `typescript` directory


----------------------------------

I'm working on the hyperlane plugin right now, and something like this will probably be needed because when creating warp routes, transactions are sent for multiple chains. I don't think theres a way to add this method to `SmartWalletClient` though because of the way that clients are created on that class, so I don't know if this method will work

```
        this.#viemClient = createPublicClient({
            chain: getViemChain(options.chain),
            transport: http(options.provider),
        });

        this.#ensClient = createPublicClient({
            chain: mainnet,
            transport: http(options.options?.ensProvider ?? ""),
        });
        ```