### PR TITLE
feat(biome): .vscode folders added to biome

### DIFF
--- a/typescript/biome.json
+++ b/typescript/biome.json
@@ -7,7 +7,7 @@
     },
     "files": {
         "ignoreUnknown": false,
-        "ignore": ["dist/**/*", "node_modules/**/*", ".next/**/*", ".turbo/**/*"]
+        "ignore": ["dist/**/*", "node_modules/**/*", ".next/**/*", ".turbo/**/*", ".vscode/**/*"]
     },
     "formatter": {
         "enabled": true,


### PR DESCRIPTION
# Background

## What does this PR do?
biome ignores .vscode folders when commiting, as these folders are already in .gitignore

## Checklist
- [x] I have tested this change and added the relevant screenshots to the PR description
- [ x I updated the [README](https://github.com/goat-sdk/goat/blob/main/README.md) if necessary to include the new plugin, wallet, chain, etc.

If you require releasing a new version of the package:
- [ ] I have added a changset for the specific package by running `pnpm change:add` from the `typescript` directory
