### PR TITLE
fix(chromia): upgrade ft4 and postchain to 2.0.2 to fix type error in balanceOf

### DIFF
--- a/typescript/.changeset/chilled-papayas-smoke.md
+++ b/typescript/.changeset/chilled-papayas-smoke.md
@@ -1,0 +1,5 @@
+---
+"@goat-sdk/wallet-chromia": minor
+---
+
+Upgrade Chromia dependencies `@chromia/ft4` and `@chromia/postchain-client` to version `2.0.2`, resolving a low-level type error in `balanceOf()` and similar calls.

--- a/typescript/examples/by-use-case/chromia-send-and-receive-tokens/package.json
+++ b/typescript/examples/by-use-case/chromia-send-and-receive-tokens/package.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "dependencies": {
         "@ai-sdk/openai": "~1.0.4",
-        "@chromia/ft4": "1.0.1",
+        "@chromia/ft4": "2.0.2",
         "@goat-sdk/adapter-vercel-ai": "0.2.10",
         "@goat-sdk/core": "0.4.9",
         "@goat-sdk/wallet-chromia": "0.2.11",
@@ -18,7 +18,7 @@
         "ai": "4.0.3",
         "chalk": "5.3.0",
         "dotenv": "^16.4.5",
-        "postchain-client": "1.20.1",
+        "postchain-client": "2.0.2",
         "zod": "3.23.8"
     }
 }

--- a/typescript/packages/wallets/chromia/package.json
+++ b/typescript/packages/wallets/chromia/package.json
@@ -13,15 +13,15 @@
     "types": "./dist/index.d.ts",
     "dependencies": {
         "@goat-sdk/core": "workspace:*",
-        "@chromia/ft4": "1.0.1",
-        "postchain-client": "1.20.1",
+        "@chromia/ft4": "2.0.2",
+        "postchain-client": "2.0.2",
         "viem": "catalog:",
         "zod": "catalog:"
     },
     "peerDependencies": {
         "@goat-sdk/core": "workspace:*",
-        "@chromia/ft4": "1.0.1",
-        "postchain-client": "1.20.1"
+        "@chromia/ft4": "2.0.2",
+        "postchain-client": "2.0.2"
     },
     "homepage": "https://ohmygoat.dev",
     "repository": {

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -2406,14 +2406,14 @@ importers:
   packages/wallets/chromia:
     dependencies:
       '@chromia/ft4':
-        specifier: 1.0.1
-        version: 1.0.1(buffer@6.0.3)(bufferutil@4.0.9)(events@3.3.0)(postchain-client@1.20.1(buffer@6.0.3)(events@3.3.0))(utf-8-validate@5.0.10)
+        specifier: 2.0.2
+        version: 2.0.2(buffer@6.0.3)(bufferutil@4.0.9)(events@3.3.0)(postchain-client@2.0.2(buffer@6.0.3)(events@3.3.0))(utf-8-validate@5.0.10)
       '@goat-sdk/core':
         specifier: workspace:*
         version: link:../../core
       postchain-client:
-        specifier: 1.20.1
-        version: 1.20.1(buffer@6.0.3)(events@3.3.0)
+        specifier: 2.0.2
+        version: 2.0.2(buffer@6.0.3)(events@3.3.0)
       viem:
         specifier: 'catalog:'
         version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -4356,6 +4356,13 @@ packages:
       buffer: ^5.x || ^6.x
       events: ^3.3.0
       postchain-client: ^1.16.1
+
+  '@chromia/ft4@2.0.2':
+    resolution: {integrity: sha512-JkW2anUAziu/XrCX3TlgV4rmdFED2KOSS52Hz8Ml4bzxlW8OlRDvSVyaYFlzJREUqVoggu/IuMEKe19n78fBEA==}
+    peerDependencies:
+      buffer: ^5.x || ^6.x
+      events: ^3.3.0
+      postchain-client: ^2.0.2
 
   '@clack/core@0.3.5':
     resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
@@ -13905,6 +13912,11 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  merklehashts@1.0.5:
+    resolution: {integrity: sha512-SAo3RZbj6u19x1LzMN4cDquxvxCOC9aCYU7B7cmuwoG8CM3T81Imqs0f0WmNSdEIryBjuJ6Mqc8m0hq0lDE1zw==}
+    peerDependencies:
+      buffer: ^5.x || ^6.x
+
   merkletreejs@0.3.11:
     resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
     engines: {node: '>= 7.6.0'}
@@ -15019,6 +15031,12 @@ packages:
 
   postchain-client@1.20.1:
     resolution: {integrity: sha512-xZVPBUsa/DxyDiOn41cs7LQ/aXu8gXdeyaaa9XNJq/O/acCqyD4Djs7ETb/BZqqH/PKVz17n9dP6hVGlwGJB5Q==}
+    peerDependencies:
+      buffer: ^5.x || ^6.x
+      events: ^3.3.0
+
+  postchain-client@2.0.2:
+    resolution: {integrity: sha512-kjEtGUIIZq2q//c6mHLx5eQoDp7YVZN6w2tQrW09+uCwkjrU2H2fbRV3w4iZl+P948jUDRBeLut/Az0TVrxwNA==}
     peerDependencies:
       buffer: ^5.x || ^6.x
       events: ^3.3.0
@@ -20672,6 +20690,16 @@ snapshots:
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       events: 3.3.0
       postchain-client: 1.20.1(buffer@6.0.3)(events@3.3.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@chromia/ft4@2.0.2(buffer@6.0.3)(bufferutil@4.0.9)(events@3.3.0)(postchain-client@2.0.2(buffer@6.0.3)(events@3.3.0))(utf-8-validate@5.0.10)':
+    dependencies:
+      buffer: 6.0.3
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      events: 3.3.0
+      postchain-client: 2.0.2(buffer@6.0.3)(events@3.3.0)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -35626,6 +35654,11 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  merklehashts@1.0.5(buffer@6.0.3):
+    dependencies:
+      '@chromia/asn1': 1.0.1
+      buffer: 6.0.3
+
   merkletreejs@0.3.11:
     dependencies:
       bignumber.js: 9.1.2
@@ -37005,6 +37038,23 @@ snapshots:
       secp256k1: 4.0.4
       stream-browserify: 3.0.0
       zod: 3.24.1
+
+  postchain-client@2.0.2(buffer@6.0.3)(events@3.3.0):
+    dependencies:
+      '@chromia/asn1': 1.0.1
+      '@types/bn.js': 5.1.6
+      axios: 1.9.0
+      buffer: 6.0.3
+      crypto-browserify: 3.12.1
+      events: 3.3.0
+      lodash: 4.17.21
+      merklehashts: 1.0.5(buffer@6.0.3)
+      secp256k1: 4.0.4
+      stream-browserify: 3.0.0
+      uuid: 11.1.0
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - debug
 
   postcss-import@15.1.0(postcss@8.5.3):
     dependencies:

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -12,8 +12,8 @@ catalog:
     "@solana/web3.js": 1.98.0
     ai: 4.0.3
     "@langchain/core": 0.3.6
-    postchain-client: 1.20.1
-    "@chromia/ft4": 1.0.1
+    postchain-client: 2.0.2
+    "@chromia/ft4": 2.0.2
     "@lit-protocol/lit-node-client": "7.0.2"
     "@lit-protocol/types": "7.0.2"
     "@lit-protocol/lit-auth-client": "7.0.2"


### PR DESCRIPTION
## What does this PR do?

Upgrades the Chromia wallet integration in GOAT SDK to use `@chromia/ft4` and `@chromia/postchain-client` version `2.0.2`.

This resolves a runtime error that occurred when calling `balanceOf(account)`:

```
The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type object
```

The issue no longer occurs after upgrading both packages to version `2.0.2`.

## Testing

Tested locally with the Chromia wallet integration. Verified:
- ✅ `balanceOf(account)` works without error
- ✅ Transfers and account calls behave as expected

## Checklist
- [x] Tested wallet functions manually
