### PR TITLE
feat: Add Boson plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ GOAT is free software, MIT licensed.
 | BetSwirl | Play casino games | [@goat-sdk/plugin-betswirl](https://www.npmjs.com/package/@goat-sdk/plugin-betswirl) |
 | BirdEye | Get token insights using BirdEye API | [@goat-sdk/plugin-birdeye](https://www.npmjs.com/package/@goat-sdk/plugin-birdeye) |
 | BMX | Get token insights using BMX API | [@goat-sdk/plugin-bmx](https://www.npmjs.com/package/@goat-sdk/plugin-bmx) |
+| Boson | Buy physical and digital goods on Boson Protocol | [@goat-sdk/plugin-boson](https://github.com/goat-sdk/goat/tree/main/typescript/packages/plugins/boson) |
 | CoinGecko | Get coin information using CoinGecko API | [@goat-sdk/plugin-coingecko](https://www.npmjs.com/package/@goat-sdk/plugin-coingecko) | [goat-sdk-plugin-coingecko](https://github.com/goat-sdk/goat/tree/main/python/src/plugins/coingecko) |
 | Coinmarketcap | Get coin information using Coinmarketcap API | [@goat-sdk/plugin-coinmarketcap](https://www.npmjs.com/package/@goat-sdk/plugin-coinmarketcap) |
 | Cosmosbank | Interact with Cosmos tokens | [@goat-sdk/plugin-cosmosbank](https://www.npmjs.com/package/@goat-sdk/plugin-cosmosbank) |

--- a/typescript/.changeset/add-plugin-boson.md
+++ b/typescript/.changeset/add-plugin-boson.md
@@ -2,7 +2,10 @@
 "@goat-sdk/plugin-boson": minor
 ---
 
-Add `@goat-sdk/plugin-boson`: a Boson Protocol plugin that exposes
-commit-to-offer over MCP for EVM chains (Polygon mainnet + Amoy testnet,
-Base mainnet + Base Sepolia, Optimism, Ethereum mainnet). Thin re-export
-of `@bosonprotocol/agentic-commerce`.
+Add `@goat-sdk/plugin-boson`: a Boson Protocol plugin that exposes the
+full Boson commerce surface over MCP for EVM chains. Thin re-export of
+`@bosonprotocol/agentic-commerce`.
+
+Supported chains: Ethereum mainnet (1), Optimism (10), Polygon (137),
+Arbitrum (42161), Base (8453), Polygon Amoy (80002), Base Sepolia (84532),
+Sepolia (11155111), Optimism Sepolia (11155420), Arbitrum Sepolia (421614).

--- a/typescript/.changeset/add-plugin-boson.md
+++ b/typescript/.changeset/add-plugin-boson.md
@@ -1,0 +1,8 @@
+---
+"@goat-sdk/plugin-boson": minor
+---
+
+Add `@goat-sdk/plugin-boson`: a Boson Protocol plugin that exposes
+commit-to-offer over MCP for EVM chains (Polygon mainnet + Amoy testnet,
+Base mainnet + Base Sepolia, Optimism, Ethereum mainnet). Thin re-export
+of `@bosonprotocol/agentic-commerce`.

--- a/typescript/examples/by-use-case/evm-boson-commit/README.md
+++ b/typescript/examples/by-use-case/evm-boson-commit/README.md
@@ -19,7 +19,7 @@ cp .env.example .env
 
 ```
 WALLET_PRIVATE_KEY=0x...   # Funded Polygon Amoy testnet wallet
-OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 ## Get a testnet wallet

--- a/typescript/examples/by-use-case/evm-boson-commit/README.md
+++ b/typescript/examples/by-use-case/evm-boson-commit/README.md
@@ -1,0 +1,60 @@
+<div align="center">
+<a href="https://github.com/goat-sdk/goat">
+<img src="https://github.com/user-attachments/assets/5fc7f121-259c-492c-8bca-f15fe7eb830c" alt="GOAT" width="100px" height="auto" style="object-fit: contain;">
+</a>
+</div>
+
+# Buy on Boson Protocol
+
+This example demonstrates an AI agent that can query and purchase physical goods on [Boson Protocol](https://www.bosonprotocol.io/) — a trust-minimized commerce protocol.
+
+The agent can browse offers, commit to purchases, and handle the full exchange lifecycle (redeem, complete, dispute) using its own EVM wallet.
+
+## Setup
+
+```bash
+cp .env.example .env
+# Fill in your keys
+```
+
+```
+WALLET_PRIVATE_KEY=0x...   # Funded Polygon Amoy testnet wallet
+OPENAI_API_KEY=sk-...
+```
+
+## Get a testnet wallet
+
+```bash
+node -e "
+const {privateKeyToAccount, generatePrivateKey} = require('viem/accounts');
+const pk = generatePrivateKey();
+console.log('PK:', pk);
+console.log('Address:', privateKeyToAccount(pk).address);
+"
+```
+
+Fund it at [faucet.polygon.technology](https://faucet.polygon.technology) (select Amoy network).
+
+## Run
+
+```bash
+pnpm install
+pnpm ts-node index.ts
+```
+
+## Example prompts
+
+- "Show me available offers on the testnet"
+- "What products can I buy with USDC?"
+- "Buy the cheapest available item"
+- "Check the status of my exchanges"
+
+<footer>
+<br/>
+<br/>
+<div>
+<a href="https://github.com/goat-sdk/goat">
+  <img src="https://github.com/user-attachments/assets/59fa5ddc-9d47-4d41-a51a-64f6798f94bd" alt="GOAT" width="100%" height="auto" style="object-fit: contain; max-width: 800px;">
+</a>
+</div>
+</footer>

--- a/typescript/examples/by-use-case/evm-boson-commit/README.md
+++ b/typescript/examples/by-use-case/evm-boson-commit/README.md
@@ -44,10 +44,29 @@ pnpm ts-node index.ts
 
 ## Example prompts
 
+- "List the configIds, then commit to offer 358 on staging-80002-0 — it's the GOAT SDK permanent demo offer (1 wei, native MATIC, ~1B commits available). Don't redeem."
 - "Show me available offers on the testnet"
 - "What products can I buy with USDC?"
-- "Buy the cheapest available item"
 - "Check the status of my exchanges"
+
+### Permanent demo offer
+
+A permanent offer is live on the staging endpoint specifically so this example
+can run end-to-end without listing your own goods first:
+
+| Field | Value |
+|-------|-------|
+| Endpoint | `https://mcp-staging.bosonprotocol.io/mcp` |
+| `configId` | `staging-80002-0` (Polygon Amoy) |
+| `offerId` | `358` |
+| Price | `1` wei (native MATIC) |
+| `exchangeToken` | `0x0000000000000000000000000000000000000000` |
+| Seller | id `42` (`0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8`) |
+| Quantity remaining | ~`999,999,998` (effectively unlimited) |
+| Valid until | year 287396 (max practical) |
+
+Commit-to-offer transaction proving it works:
+[`0xcd81dc5c2c2e7d05ed8a4c84e0263f79fc16fc437cc2a65ce5e3028eecf46980`](https://amoy.polygonscan.com/tx/0xcd81dc5c2c2e7d05ed8a4c84e0263f79fc16fc437cc2a65ce5e3028eecf46980).
 
 <footer>
 <br/>

--- a/typescript/examples/by-use-case/evm-boson-commit/example-config.md
+++ b/typescript/examples/by-use-case/evm-boson-commit/example-config.md
@@ -8,10 +8,13 @@ Copy the variables below into a `.env` file in this directory. Never commit `.en
 # =============================================================================
 
 # Boson MCP server endpoint
-BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
+# Staging (testnets — Polygon Amoy, Base Sepolia, Sepolia, OP Sepolia, Arbitrum Sepolia):
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
+# Production (mainnets — Ethereum, Optimism, Base):
+# BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
 
 # AI model key
-OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
 
 # =============================================================================
 # Required — write operations (commit, redeem, dispute, etc.)
@@ -42,7 +45,7 @@ The example supports both read-only and write modes depending on which env vars 
 
 | Mode | Required vars |
 |------|--------------|
-| Read-only (browse offers, exchanges, disputes) | `BOSON_MCP_URL`, `OPENAI_API_KEY` |
+| Read-only (browse offers, exchanges, disputes) | `BOSON_MCP_URL`, `ANTHROPIC_API_KEY` |
 | Write (commit, redeem, raise dispute, etc.) | + `WALLET_PRIVATE_KEY` |
 
 For write operations, the wallet must have:

--- a/typescript/examples/by-use-case/evm-boson-commit/example-config.md
+++ b/typescript/examples/by-use-case/evm-boson-commit/example-config.md
@@ -1,0 +1,50 @@
+# Environment configuration
+
+Copy the variables below into a `.env` file in this directory. Never commit `.env` to version control.
+
+```bash
+# =============================================================================
+# Required — read-only usage
+# =============================================================================
+
+# Boson MCP server endpoint
+BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
+
+# AI model key
+OPENAI_API_KEY=sk-...
+
+# =============================================================================
+# Required — write operations (commit, redeem, dispute, etc.)
+# =============================================================================
+
+# EVM wallet private key — TESTNET ONLY. Never use a production key.
+# Generate a fresh key:
+#   node -e "const {generatePrivateKey}=require('viem/accounts'); console.log(generatePrivateKey())"
+# Fund it at: https://faucet.polygon.technology (select Amoy network)
+WALLET_PRIVATE_KEY=0x...
+
+# =============================================================================
+# Optional overrides
+# =============================================================================
+
+# MCP request timeout in milliseconds (default: 30000)
+# BOSON_TIMEOUT_MS=30000
+
+# Default configId (discovered automatically via boson_get_config_ids if not set)
+# Testnet:  testing-80002-0
+# Mainnet:  production-137-0
+# BOSON_CONFIG_ID=testing-80002-0
+```
+
+## Read-only vs write
+
+The example supports both read-only and write modes depending on which env vars are set.
+
+| Mode | Required vars |
+|------|--------------|
+| Read-only (browse offers, exchanges, disputes) | `BOSON_MCP_URL`, `OPENAI_API_KEY` |
+| Write (commit, redeem, raise dispute, etc.) | + `WALLET_PRIVATE_KEY` |
+
+For write operations, the wallet must have:
+- Testnet MATIC for gas (obtainable free from the Amoy faucet)
+- The payment token required by the offer (check `boson_get_supported_tokens`)

--- a/typescript/examples/by-use-case/evm-boson-commit/index.ts
+++ b/typescript/examples/by-use-case/evm-boson-commit/index.ts
@@ -1,0 +1,109 @@
+/**
+ * Boson Protocol — AI agent commerce example
+ *
+ * This example shows an AI agent that can:
+ * 1. Query available product offers on Boson Protocol
+ * 2. Commit to an offer (purchase) using its own wallet
+ * 3. Handle the full exchange lifecycle (redeem, complete, dispute)
+ *
+ * Chain: Polygon Amoy testnet (80002) — set CHAIN=polygon for mainnet
+ *
+ * Required env vars:
+ *   WALLET_PRIVATE_KEY   — 0x-prefixed private key for a funded Amoy wallet
+ *   OPENAI_API_KEY       — OpenAI API key
+ *   BOSON_MCP_URL        — (optional) override the default MCP endpoint
+ */
+
+import readline from "node:readline";
+import { openai } from "@ai-sdk/openai";
+import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
+import { boson } from "@goat-sdk/plugin-boson";
+import { viem } from "@goat-sdk/wallet-viem";
+import { type CoreMessage, generateText } from "ai";
+import { http, createWalletClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { polygonAmoy } from "viem/chains";
+
+require("dotenv").config();
+
+const BOSON_MCP_URL = process.env.BOSON_MCP_URL ?? "https://mcp.bosonprotocol.io/mcp";
+
+// 1. Create a wallet client for Polygon Amoy testnet
+const account = privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as `0x${string}`);
+
+const walletClient = createWalletClient({
+    account,
+    transport: http(),
+    chain: polygonAmoy,
+});
+
+(async () => {
+    // 2. Get on-chain tools including the Boson plugin
+    const tools = await getOnChainTools({
+        wallet: viem(walletClient),
+        plugins: [boson({ mcpUrl: BOSON_MCP_URL })],
+    });
+
+    const systemPrompt = `You are an AI agent with access to Boson Protocol, a trust-minimized commerce platform for physical goods.
+
+You can:
+- Query product offers with boson_get_offers
+- Commit to (purchase) an offer with boson_commit_to_offer
+- Check exchange status with boson_get_exchanges
+- Redeem a voucher with boson_redeem_voucher
+- Complete an exchange with boson_complete_exchange
+- Raise a dispute with boson_raise_dispute if something goes wrong
+
+Always call boson_get_config_ids first to discover the available deployment (use 'testing-80002-0' for testnet).
+
+When committing to an offer, your wallet address is the buyer address. Use get_address to find it.
+
+Before committing, always:
+1. Check available offers and confirm the price with the user
+2. Check token approval with boson_approve_exchange_token if the payment token is not native MATIC
+3. Confirm the user wants to proceed`;
+
+    const messages: CoreMessage[] = [];
+
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    console.log("Boson Protocol AI Agent ready. Type 'exit' to quit.\n");
+    console.log(`Wallet: ${account.address}`);
+    console.log("Chain: Polygon Amoy (80002)\n");
+
+    while (true) {
+        const prompt = await new Promise<string>((resolve) => {
+            rl.question("You: ", resolve);
+        });
+
+        if (prompt === "exit") {
+            rl.close();
+            break;
+        }
+
+        messages.push({ role: "user", content: prompt });
+
+        try {
+            const result = await generateText({
+                model: openai("gpt-4o"),
+                system: systemPrompt,
+                messages,
+                tools,
+                maxSteps: 10,
+                onStepFinish: (event) => {
+                    if (event.toolResults.length > 0) {
+                        console.log("\n[Tool calls]", JSON.stringify(event.toolResults, null, 2));
+                    }
+                },
+            });
+
+            messages.push({ role: "assistant", content: result.text });
+            console.log(`\nAgent: ${result.text}\n`);
+        } catch (error) {
+            console.error("Error:", error);
+        }
+    }
+})();

--- a/typescript/examples/by-use-case/evm-boson-commit/index.ts
+++ b/typescript/examples/by-use-case/evm-boson-commit/index.ts
@@ -10,14 +10,16 @@
  *
  * Required env vars:
  *   WALLET_PRIVATE_KEY   — 0x-prefixed private key for a funded Amoy wallet
- *   OPENAI_API_KEY       — OpenAI API key
- *   BOSON_MCP_URL        — (optional) override the default MCP endpoint
+ *   ANTHROPIC_API_KEY    — Anthropic API key
+ *   BOSON_MCP_URL        — (optional) override; defaults to the staging MCP
+ *                          (mcp-staging.bosonprotocol.io) so Polygon Amoy works.
+ *                          For mainnet flows use https://mcp.bosonprotocol.io/mcp.
  */
 
 import readline from "node:readline";
-import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
 import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
-import { boson } from "@goat-sdk/plugin-boson";
+import { bosonProtocolPlugin } from "@goat-sdk/plugin-boson";
 import { viem } from "@goat-sdk/wallet-viem";
 import { type CoreMessage, generateText } from "ai";
 import { http, createWalletClient } from "viem";
@@ -26,7 +28,10 @@ import { polygonAmoy } from "viem/chains";
 
 require("dotenv").config();
 
-const BOSON_MCP_URL = process.env.BOSON_MCP_URL ?? "https://mcp.bosonprotocol.io/mcp";
+// Default to staging because Polygon Amoy (the chain hardcoded below) only lives
+// on the staging MCP. For mainnet runs (Base/Optimism/Ethereum), set
+// BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp and pick a matching chain.
+const BOSON_MCP_URL = process.env.BOSON_MCP_URL ?? "https://mcp-staging.bosonprotocol.io/mcp";
 
 // 1. Create a wallet client for Polygon Amoy testnet
 const account = privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as `0x${string}`);
@@ -41,7 +46,7 @@ const walletClient = createWalletClient({
     // 2. Get on-chain tools including the Boson plugin
     const tools = await getOnChainTools({
         wallet: viem(walletClient),
-        plugins: [boson({ mcpUrl: BOSON_MCP_URL })],
+        plugins: [bosonProtocolPlugin({ url: BOSON_MCP_URL })],
     });
 
     const systemPrompt = `You are an AI agent with access to Boson Protocol, a trust-minimized commerce platform for physical goods.
@@ -88,7 +93,7 @@ Before committing, always:
 
         try {
             const result = await generateText({
-                model: openai("gpt-4o"),
+                model: anthropic("claude-sonnet-4-6"),
                 system: systemPrompt,
                 messages,
                 tools,

--- a/typescript/examples/by-use-case/evm-boson-commit/package.json
+++ b/typescript/examples/by-use-case/evm-boson-commit/package.json
@@ -9,7 +9,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@ai-sdk/openai": "~1.0.4",
+        "@ai-sdk/anthropic": "~1.0.0",
         "@goat-sdk/adapter-vercel-ai": "0.2.10",
         "@goat-sdk/core": "workspace:*",
         "@goat-sdk/plugin-boson": "workspace:*",

--- a/typescript/examples/by-use-case/evm-boson-commit/package.json
+++ b/typescript/examples/by-use-case/evm-boson-commit/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "goat-examples-evm-boson-commit",
+    "version": "0.0.0",
+    "description": "Buy physical goods on Boson Protocol using an AI agent",
+    "private": true,
+    "scripts": {
+        "test": "vitest run --passWithNoTests"
+    },
+    "author": "",
+    "license": "MIT",
+    "dependencies": {
+        "@ai-sdk/openai": "~1.0.4",
+        "@goat-sdk/adapter-vercel-ai": "0.2.10",
+        "@goat-sdk/core": "workspace:*",
+        "@goat-sdk/plugin-boson": "workspace:*",
+        "@goat-sdk/wallet-evm": "workspace:*",
+        "@goat-sdk/wallet-viem": "0.2.12",
+        "ai": "~4.0.3",
+        "dotenv": "^16.4.5",
+        "viem": "2.23.4",
+        "zod": "3.23.8"
+    }
+}

--- a/typescript/examples/by-use-case/evm-boson-commit/tsconfig.json
+++ b/typescript/examples/by-use-case/evm-boson-commit/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../../tsconfig.base.json",
+    "include": ["*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/plugins/boson/README.md
+++ b/typescript/packages/plugins/boson/README.md
@@ -42,14 +42,12 @@ const plugin = bosonProtocolPlugin({
 
 ### Endpoints & live deployments
 
-The plugin's [`supportsChain`](#compatibility) returns `true` for every chain id below, but offers only resolve through the deployment that actually backs the chain. Pick the endpoint that matches the chain you wallet is on:
+Pick the endpoint that matches the chain your wallet is on:
 
-| Endpoint | URL | Live chain ids (`get_config_ids`) |
-|----------|-----|------------------------------------|
-| Production | `https://mcp.bosonprotocol.io/mcp` | Ethereum mainnet (1), Optimism (10), Base (8453) |
+| Endpoint | URL | Chains |
+|----------|-----|--------|
+| Production | `https://mcp.bosonprotocol.io/mcp` | Ethereum mainnet (1), Optimism (10), Polygon (137), Arbitrum (42161), Base (8453) |
 | Staging | `https://mcp-staging.bosonprotocol.io/mcp` | Polygon Amoy (80002), Base Sepolia (84532), Sepolia (11155111), Optimism Sepolia (11155420), Arbitrum Sepolia (421614) |
-
-Polygon mainnet (137) and Arbitrum (42161) are reserved chain ids — `supportsChain` returns `true` for both, but neither endpoint exposes a live deployment in `get_config_ids` today.
 
 ## Quick start
 

--- a/typescript/packages/plugins/boson/README.md
+++ b/typescript/packages/plugins/boson/README.md
@@ -1,0 +1,244 @@
+<div align="center">
+<a href="https://github.com/goat-sdk/goat">
+<img src="https://github.com/user-attachments/assets/5fc7f121-259c-492c-8bca-f15fe7eb830c" alt="GOAT" width="100px" height="auto" style="object-fit: contain;">
+</a>
+</div>
+
+# Boson Protocol GOAT Plugin
+
+Enable AI agents to buy and sell physical goods using [Boson Protocol](https://www.bosonprotocol.io/) — a trust-minimized commerce protocol.
+
+This package is a thin re-export of the goat-sdk plugin shipped by [`@bosonprotocol/agentic-commerce`](https://www.npmjs.com/package/@bosonprotocol/agentic-commerce). Tools cover the commerce lifecycle (offers, exchanges, disputes, sellers, funds, metadata, and agent registration) and route signing through the GOAT wallet abstraction — no private keys are passed to the MCP server.
+
+## Installation
+
+```bash
+npm install @goat-sdk/plugin-boson
+yarn add @goat-sdk/plugin-boson
+pnpm add @goat-sdk/plugin-boson
+```
+
+## Requirements
+
+- Node.js `>=20.12.2 <23`
+- GOAT SDK `@goat-sdk/core` (workspace peer)
+- An EVM wallet client (`@goat-sdk/wallet-viem` or equivalent)
+- A network whose chain id is in `@bosonprotocol/common`'s `supportedChainIds` (Ethereum, Polygon, Base, Optimism, Arbitrum, plus the matching testnets)
+
+## Configuration
+
+```typescript
+import { bosonProtocolPlugin } from "@goat-sdk/plugin-boson";
+
+const plugin = bosonProtocolPlugin({
+    // Required: Boson MCP server endpoint
+    url: "https://mcp.bosonprotocol.io/mcp",
+});
+```
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `url` | `string` | Yes | Boson MCP server endpoint URL |
+
+## Quick start
+
+### Read-only (no wallet funding required)
+
+```typescript
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { polygonAmoy } from "viem/chains";
+import { getOnChainTools } from "@goat-sdk/adapter-vercel-ai";
+import { viem } from "@goat-sdk/wallet-viem";
+import { bosonProtocolPlugin } from "@goat-sdk/plugin-boson";
+
+const walletClient = createWalletClient({
+    account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as `0x${string}`),
+    transport: http(),
+    chain: polygonAmoy,
+});
+
+const tools = await getOnChainTools({
+    wallet: viem(walletClient),
+    plugins: [
+        bosonProtocolPlugin({
+            url: process.env.BOSON_MCP_URL as string,
+        }),
+    ],
+});
+
+// First call: discover available deployments
+// tools["get_config_ids"].execute({})
+// => ["staging-80002-0", "production-137-0"]
+
+// Then query offers
+// tools["get_offers"].execute({ configId: "staging-80002-0", first: 10 })
+```
+
+### Write operation (commit to an offer)
+
+```typescript
+const result = await tools["commit_to_offer"].execute({
+    offerId: "42",
+    buyer: account.address,
+    signerAddress: account.address,
+    configId: "staging-80002-0",
+});
+// result.success === true => result.message.hash is the on-chain transaction hash
+```
+
+## Write operations
+
+Write tools call the Boson MCP server to obtain an unsigned transaction payload, then sign and broadcast using the GOAT wallet client. The MCP server never sees private keys.
+
+Results are shaped:
+
+```typescript
+type WriteResult =
+    | { success: true; message: { hash: string } }
+    | { success: false; error: string };
+```
+
+Use a testnet first. Configure `configId: "staging-80002-0"` and fund a wallet on [Polygon Amoy](https://faucet.polygon.technology/) before moving to production.
+
+## Tool reference
+
+Call `get_config_ids` first on every session to discover valid `configId` values.
+
+### Offers
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_offers` | R | Query available product offers |
+| `get_all_products_with_not_voided_variants` | R | Query product catalogue (non-voided variants only) |
+| `validate_metadata` | R | Validate offer metadata schema before creating an offer |
+| `render_contractual_agreement` | R | Render a buyer-seller agreement from a template |
+| `create_offer` | W | Create a new product offer |
+| `create_offer_with_condition` | W | Create an offer with a token-gating condition |
+| `void_offer` | W | Void an offer, preventing new commits |
+| `void_non_listed_offer` | W | Void a non-listed offer |
+| `void_non_listed_offer_batch` | W | Void multiple non-listed offers in one transaction |
+| `sign_full_offer` | W | Sign a full offer |
+| `create_offer_and_commit` | W | Create an offer and immediately commit to it |
+
+### Exchanges
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_exchanges` | R | Query exchange records |
+| `approve_exchange_token` | W | Approve ERC20 token spend before committing |
+| `commit_to_offer` | W | Purchase an offer (issues a voucher) |
+| `commit_to_buyer_offer` | W | Commit to a buyer-specific offer |
+| `revoke_voucher` | W | Revoke a voucher (seller action — cannot fulfil) |
+| `cancel_voucher` | W | Cancel a voucher (buyer action — no longer wants item) |
+| `redeem_voucher` | W | Redeem a voucher to claim the item |
+| `complete_exchange` | W | Complete an exchange, releasing funds |
+
+### Disputes
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_disputes` | R | Query dispute records |
+| `get_dispute_by_id` | R | Fetch a single dispute by ID |
+| `get_dispute_resolvers` | R | List available dispute resolvers |
+| `raise_dispute` | W | Raise a dispute on an exchange |
+| `retract_dispute` | W | Retract a previously raised dispute |
+| `escalate_dispute` | W | Escalate to the designated resolver |
+| `resolve_dispute` | W | Resolve a dispute by mutual agreement |
+| `create_dispute_resolution_proposal` | W | Propose a resolution for the counterparty to accept |
+| `decide_dispute` | W | Decide a dispute (resolver action) |
+| `refuse_escalated_dispute` | W | Refuse to handle an escalated dispute (resolver) |
+| `expire_escalated_dispute` | W | Expire an unresolved escalated dispute |
+| `extend_dispute_timeout` | W | Extend the dispute window (seller action) |
+| `expire_dispute` | W | Expire a dispute that was not escalated in time |
+| `expire_dispute_batch` | W | Expire multiple disputes in one transaction |
+
+### Sellers
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_sellers` | R | Query seller records |
+| `get_sellers_by_address` | R | Look up sellers by wallet address |
+| `create_seller` | W | Register a new seller account |
+| `update_seller` | W | Update an existing seller account |
+| `create_buyer` | W | Register a buyer account |
+
+### Funds
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_funds` | R | Query treasury fund balances |
+| `get_supported_tokens` | R | List accepted payment tokens |
+| `deposit_funds` | W | Deposit funds into a seller's escrow account |
+| `withdraw_funds` | W | Withdraw available funds from escrow |
+
+### Metadata storage
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `store_product_v1_metadata` | W | Store product V1 metadata |
+| `store_bundle_metadata` | W | Store bundle metadata |
+| `store_base_metadata` | W | Store base metadata |
+| `store_bundle_item_product_v1_metadata` | W | Store bundle item product V1 metadata |
+| `store_bundle_item_nft_metadata` | W | Store bundle item NFT metadata |
+
+### Agent registration
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_registered_agents` | R | List registered AI agents |
+| `register_agent` | W | Register an AI agent to earn facilitation fees |
+
+### Protocol / config
+
+| Tool | R/W | Description |
+|------|-----|-------------|
+| `get_config_ids` | R | List available deployments — call this first |
+| `sign_typed_data` | W | Produce an EIP-712 signature via the wallet client |
+| `send_meta_transaction` | W | Submit a gasless meta-transaction |
+| `send_native_meta_transaction` | W | Submit a native meta-transaction |
+| `send_forwarded_meta_transaction` | W | Submit a forwarded meta-transaction |
+
+## Testing
+
+```bash
+pnpm --filter @goat-sdk/plugin-boson test
+```
+
+For end-to-end coverage against a real MCP server and chain, see the upstream [`@bosonprotocol/agentic-commerce`](https://www.npmjs.com/package/@bosonprotocol/agentic-commerce) repository.
+
+## Security
+
+- **Never use a production wallet for testing.** Use a dedicated testnet key.
+- The MCP server returns unsigned transaction payloads. Private keys are handled exclusively by the GOAT wallet client on the caller's machine.
+
+## Compatibility
+
+| Dependency | Version |
+|------------|---------|
+| `@bosonprotocol/agentic-commerce` | `^1.2.4` |
+| `@goat-sdk/core` | `workspace:*` |
+| `@goat-sdk/wallet-evm` | `workspace:*` |
+| `viem` | `2.23.4` |
+| `zod` | `3.23.8` |
+
+Supported chain ids come from `@bosonprotocol/common`'s `supportedChainIds`. As of the pinned version this includes Ethereum (1), Optimism (10), Polygon (137), Arbitrum (42161), Base (8453), and the corresponding testnets (Sepolia 11155111, Optimism Sepolia 11155420, Polygon Amoy 80002, Arbitrum Sepolia 421614, Base Sepolia 84532).
+
+## Boson Protocol resources
+
+| Resource | URL |
+|----------|-----|
+| Agent integration guide | [docs.bosonprotocol.io/using-the-protocol/agent-integration](https://docs.bosonprotocol.io/using-the-protocol/agent-integration) |
+| dACP tool reference | [docs.bosonprotocol.io/using-the-protocol/dacp-tools](https://docs.bosonprotocol.io/using-the-protocol/dacp-tools) |
+| Agent Builder (reference implementations) | [github.com/bosonprotocol/agent-builder](https://github.com/bosonprotocol/agent-builder) |
+| Protocol documentation | [docs.bosonprotocol.io](https://docs.bosonprotocol.io) |
+
+<footer>
+<br/>
+<br/>
+<div>
+<a href="https://github.com/goat-sdk/goat">
+  <img src="https://github.com/user-attachments/assets/59fa5ddc-9d47-4d41-a51a-64f6798f94bd" alt="GOAT" width="100%" height="auto" style="object-fit: contain; max-width: 800px;">
+</a>
+</div>
+</footer>

--- a/typescript/packages/plugins/boson/README.md
+++ b/typescript/packages/plugins/boson/README.md
@@ -40,6 +40,17 @@ const plugin = bosonProtocolPlugin({
 |--------|------|----------|-------------|
 | `url` | `string` | Yes | Boson MCP server endpoint URL |
 
+### Endpoints & live deployments
+
+The plugin's [`supportsChain`](#compatibility) returns `true` for every chain id below, but offers only resolve through the deployment that actually backs the chain. Pick the endpoint that matches the chain you wallet is on:
+
+| Endpoint | URL | Live chain ids (`get_config_ids`) |
+|----------|-----|------------------------------------|
+| Production | `https://mcp.bosonprotocol.io/mcp` | Ethereum mainnet (1), Optimism (10), Base (8453) |
+| Staging | `https://mcp-staging.bosonprotocol.io/mcp` | Polygon Amoy (80002), Base Sepolia (84532), Sepolia (11155111), Optimism Sepolia (11155420), Arbitrum Sepolia (421614) |
+
+Polygon mainnet (137) and Arbitrum (42161) are reserved chain ids — `supportsChain` returns `true` for both, but neither endpoint exposes a live deployment in `get_config_ids` today.
+
 ## Quick start
 
 ### Read-only (no wallet funding required)

--- a/typescript/packages/plugins/boson/README.md
+++ b/typescript/packages/plugins/boson/README.md
@@ -203,10 +203,11 @@ Call `get_config_ids` first on every session to discover valid `configId` values
 | Tool | R/W | Description |
 |------|-----|-------------|
 | `get_config_ids` | R | List available deployments — call this first |
-| `sign_typed_data` | W | Produce an EIP-712 signature via the wallet client |
 | `send_meta_transaction` | W | Submit a gasless meta-transaction |
 | `send_native_meta_transaction` | W | Submit a native meta-transaction |
 | `send_forwarded_meta_transaction` | W | Submit a forwarded meta-transaction |
+
+EIP-712 signing is handled by the EVM wallet plugin (`sign_typed_data_evm` on `@goat-sdk/wallet-evm`), not by this plugin.
 
 ## Testing
 

--- a/typescript/packages/plugins/boson/__tests__/boson.test.ts
+++ b/typescript/packages/plugins/boson/__tests__/boson.test.ts
@@ -30,6 +30,9 @@ describe("BosonProtocolPlugin", () => {
         ["Arbitrum", 42161],
         ["Polygon Amoy testnet", 80002],
         ["Base Sepolia testnet", 84532],
+        ["Sepolia testnet", 11155111],
+        ["Optimism Sepolia testnet", 11155420],
+        ["Arbitrum Sepolia testnet", 421614],
     ])("supports %s (%i)", (_name, chainId) => {
         const plugin = bosonProtocolPlugin({ url: MCP_URL });
         expect(plugin.supportsChain(evm(chainId))).toBe(true);

--- a/typescript/packages/plugins/boson/__tests__/boson.test.ts
+++ b/typescript/packages/plugins/boson/__tests__/boson.test.ts
@@ -1,0 +1,49 @@
+import type { EvmChain } from "@goat-sdk/core";
+import { describe, expect, it } from "vitest";
+import { BosonProtocolPlugin, bosonProtocolPlugin } from "../src";
+
+const MCP_URL = "https://mcp.bosonprotocol.io/mcp";
+
+const evm = (id: number, name = "Ether", symbol = "ETH"): EvmChain => ({
+    type: "evm",
+    id,
+    nativeCurrency: { name, symbol, decimals: 18 },
+});
+
+describe("BosonProtocolPlugin", () => {
+    it("instantiates via factory function", () => {
+        const plugin = bosonProtocolPlugin({ url: MCP_URL });
+        expect(plugin).toBeInstanceOf(BosonProtocolPlugin);
+        expect(plugin.name).toBe("boson-protocol");
+    });
+
+    it("exposes at least one tool provider", () => {
+        const plugin = bosonProtocolPlugin({ url: MCP_URL });
+        expect(plugin.toolProviders.length).toBeGreaterThan(0);
+    });
+
+    it.each([
+        ["Ethereum mainnet", 1],
+        ["Optimism", 10],
+        ["Polygon", 137],
+        ["Base", 8453],
+        ["Arbitrum", 42161],
+        ["Polygon Amoy testnet", 80002],
+        ["Base Sepolia testnet", 84532],
+    ])("supports %s (%i)", (_name, chainId) => {
+        const plugin = bosonProtocolPlugin({ url: MCP_URL });
+        expect(plugin.supportsChain(evm(chainId))).toBe(true);
+    });
+
+    it("does not support BNB Smart Chain (56)", () => {
+        const plugin = bosonProtocolPlugin({ url: MCP_URL });
+        expect(plugin.supportsChain(evm(56, "BNB", "BNB"))).toBe(false);
+    });
+
+    it("does not support non-EVM chains", () => {
+        const plugin = bosonProtocolPlugin({ url: MCP_URL });
+        const solana = { type: "solana", id: 0, nativeCurrency: { name: "SOL", symbol: "SOL", decimals: 9 } };
+        // biome-ignore lint/suspicious/noExplicitAny: deliberately passing a non-EVM chain
+        expect(plugin.supportsChain(solana as any)).toBe(false);
+    });
+});

--- a/typescript/packages/plugins/boson/docs/architecture.md
+++ b/typescript/packages/plugins/boson/docs/architecture.md
@@ -1,0 +1,57 @@
+# Architecture — @goat-sdk/plugin-boson
+
+## Scope
+
+This package is a thin re-export of the goat-sdk plugin shipped by [`@bosonprotocol/agentic-commerce`](https://www.npmjs.com/package/@bosonprotocol/agentic-commerce). All real logic — MCP transport, tool surface, signing, chain gating — lives in that upstream package; this wrapper exists to publish it under the `@goat-sdk/plugin-boson` name and version line.
+
+```
+src/index.ts
+    └── re-exports BosonProtocolPlugin / bosonProtocolPlugin / BosonProtocolOptions
+        from @bosonprotocol/agentic-commerce
+```
+
+## Component map
+
+```
+Agent / Framework (Vercel AI, LangChain, ElizaOS, ...)
+        │
+        ▼
+@goat-sdk/adapter-*                ← converts ToolBase[] to framework-native tools
+        │
+        ▼
+BosonProtocolPlugin (PluginBase)   ← from @bosonprotocol/agentic-commerce
+        │   chain gating uses supportedChainIds from @bosonprotocol/common
+        ▼
+BosonProtocolPluginService         ← @Tool-decorated read + write methods
+        │
+        ├── BosonMCPClient         ← @modelcontextprotocol/sdk client
+        │
+        └── EVMWalletClient        ← GOAT wallet abstraction (sendTransaction)
+```
+
+## Read execution model
+
+Read tools call `BosonMCPClient` directly and return `{success: true, message}` or `{success: false, error}`. No wallet interaction.
+
+## Write execution model
+
+Write tools obtain an unsigned transaction payload from the MCP server, then route it through `walletClient.sendTransaction`. The MCP server never receives private keys.
+
+```
+agent calls tool
+    → BosonProtocolPluginService method
+    → mcpClient.<method>(params)
+    → MCP server returns { transactionData: { to, data, value, ... } }
+    → walletClient.sendTransaction(...)
+    → return { success: true, message: { hash } }
+```
+
+EIP-712 typed-data signing is not currently surfaced by `BosonProtocolPluginService`; if needed it must be added upstream in `@bosonprotocol/agentic-commerce`.
+
+## Chain support
+
+`BosonProtocolPlugin.supportsChain()` returns `true` for any EVM chain whose id is in `supportedChainIds` from `@bosonprotocol/common` (configurable via the `CONFIG_IDS` env var; defaults include Ethereum, Polygon, Base, Optimism, Arbitrum and the corresponding testnets).
+
+## Adding a new tool
+
+This wrapper does not own any tools. Open an issue or pull request against [`@bosonprotocol/agentic-commerce`](https://www.npmjs.com/package/@bosonprotocol/agentic-commerce) to add or modify tools, then bump the pinned version in `package.json` to pick up the change.

--- a/typescript/packages/plugins/boson/package.json
+++ b/typescript/packages/plugins/boson/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "@goat-sdk/plugin-boson",
+    "version": "0.1.0",
+    "files": ["dist/**/*", "README.md", "package.json"],
+    "scripts": {
+        "build": "tsup",
+        "clean": "rm -rf dist",
+        "test": "vitest run --passWithNoTests"
+    },
+    "sideEffects": false,
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "dependencies": {
+        "@bosonprotocol/agentic-commerce": "^1.2.4",
+        "@goat-sdk/core": "workspace:*",
+        "@goat-sdk/wallet-evm": "workspace:*",
+        "viem": "catalog:",
+        "zod": "catalog:"
+    },
+    "peerDependencies": {
+        "@goat-sdk/core": "workspace:*",
+        "viem": "catalog:"
+    },
+    "homepage": "https://ohmygoat.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/goat-sdk/goat.git"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/goat-sdk/goat/issues"
+    },
+    "keywords": ["ai", "agents", "web3", "boson", "commerce", "ecommerce"],
+    "devDependencies": {
+        "@swc/core": "1.10.1",
+        "unplugin-swc": "^1.5.9"
+    }
+}

--- a/typescript/packages/plugins/boson/src/index.ts
+++ b/typescript/packages/plugins/boson/src/index.ts
@@ -1,0 +1,5 @@
+export {
+    BosonProtocolPlugin,
+    bosonProtocolPlugin,
+    type BosonProtocolOptions,
+} from "@bosonprotocol/agentic-commerce";

--- a/typescript/packages/plugins/boson/tsconfig.json
+++ b/typescript/packages/plugins/boson/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@goat-sdk/core": ["./node_modules/@goat-sdk/core/src/index.ts"],
+            "@goat-sdk/wallet-evm": ["./node_modules/@goat-sdk/wallet-evm/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/typescript/packages/plugins/boson/tsup.config.ts
+++ b/typescript/packages/plugins/boson/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "tsup";
+import { treeShakableConfig } from "../../../tsup.config.base";
+
+export default defineConfig({
+    ...treeShakableConfig,
+});

--- a/typescript/packages/plugins/boson/vitest.config.ts
+++ b/typescript/packages/plugins/boson/vitest.config.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import swc from "unplugin-swc";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    plugins: [
+        swc.vite({
+            module: { type: "es6" },
+            jsc: {
+                parser: { syntax: "typescript", decorators: true },
+                transform: { legacyDecorator: true, decoratorMetadata: true },
+                target: "es2022",
+            },
+        }),
+    ],
+    resolve: {
+        alias: {
+            "@goat-sdk/core": path.resolve(__dirname, "node_modules/@goat-sdk/core/src/index.ts"),
+            "@goat-sdk/wallet-evm": path.resolve(__dirname, "node_modules/@goat-sdk/wallet-evm/src/index.ts"),
+        },
+    },
+    test: {
+        globals: false,
+    },
+});

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -550,9 +550,9 @@ importers:
 
   examples/by-use-case/evm-boson-commit:
     dependencies:
-      '@ai-sdk/openai':
-        specifier: ~1.0.4
-        version: 1.0.20(zod@3.23.8)
+      '@ai-sdk/anthropic':
+        specifier: ~1.0.0
+        version: 1.0.9(zod@3.23.8)
       '@goat-sdk/adapter-vercel-ai':
         specifier: 0.2.10
         version: 0.2.10(@goat-sdk/core@packages+core)(ai@4.0.22(react@18.3.1)(zod@3.23.8))(zod@3.23.8)
@@ -2814,6 +2814,12 @@ packages:
 
   '@ai-sdk/anthropic@0.0.56':
     resolution: {integrity: sha512-FC/XbeFANFp8rHH+zEZF34cvRu9T42rQxw9QnUzJ1LXTi1cWjxYOx2Zo4vfg0iofxxqgOe4fT94IdT2ERQ89bA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/anthropic@1.0.9':
+    resolution: {integrity: sha512-gYKZu+lT0yw/St62YC+ZsQ9IR/PC8G7ssZtnGsht2Im4Ix8MWr1dQHMq9h9Sedulxom+IbdAjAUCgNfqy7F7ZQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -18407,6 +18413,12 @@ snapshots:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
       zod: 3.23.8
 
+  '@ai-sdk/anthropic@1.0.9(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.0.4
+      '@ai-sdk/provider-utils': 2.0.8(zod@3.23.8)
+      zod: 3.23.8
+
   '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -31572,9 +31584,9 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
-  acorn-typescript@1.4.13(acorn@8.14.1):
+  acorn-typescript@1.4.13(acorn@8.16.0):
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.16.0
 
   acorn-walk@8.3.4:
     dependencies:
@@ -39837,8 +39849,8 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.7
-      acorn: 8.14.1
-      acorn-typescript: 1.4.13(acorn@8.14.1)
+      acorn: 8.16.0
+      acorn-typescript: 1.4.13(acorn@8.16.0)
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 1.0.3
       viem:
         specifier: 2.22.19
-        version: 2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+        version: 2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -289,7 +289,7 @@ importers:
         version: 1.0.20(zod@3.23.8)
       '@goat-sdk/adapter-mastra':
         specifier: 0.1.0
-        version: 0.1.0(@goat-sdk/core@0.4.9(zod@3.23.8))(ai@4.3.5(react@18.3.1)(zod@3.23.8))(zod@3.23.8)
+        version: 0.1.0(@goat-sdk/core@0.4.9(zod@3.23.8))(ai@4.3.19(react@18.3.1)(zod@3.23.8))(zod@3.23.8)
       '@goat-sdk/core':
         specifier: 0.4.9
         version: 0.4.9(zod@3.23.8)
@@ -537,6 +537,39 @@ importers:
         version: 0.3.0(@goat-sdk/core@0.5.0(zod@3.23.8))(@goat-sdk/wallet-evm@0.3.0(@goat-sdk/core@0.5.0(zod@3.23.8))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10))(viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8))
       ai:
         specifier: 4.0.22
+        version: 4.0.22(react@18.3.1)(zod@3.23.8)
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.5.0
+      viem:
+        specifier: 2.23.4
+        version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+      zod:
+        specifier: 3.23.8
+        version: 3.23.8
+
+  examples/by-use-case/evm-boson-commit:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ~1.0.4
+        version: 1.0.20(zod@3.23.8)
+      '@goat-sdk/adapter-vercel-ai':
+        specifier: 0.2.10
+        version: 0.2.10(@goat-sdk/core@packages+core)(ai@4.0.22(react@18.3.1)(zod@3.23.8))(zod@3.23.8)
+      '@goat-sdk/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@goat-sdk/plugin-boson':
+        specifier: workspace:*
+        version: link:../../../packages/plugins/boson
+      '@goat-sdk/wallet-evm':
+        specifier: workspace:*
+        version: link:../../../packages/wallets/evm
+      '@goat-sdk/wallet-viem':
+        specifier: 0.2.12
+        version: 0.2.12(@goat-sdk/wallet-evm@packages+wallets+evm)(viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8))
+      ai:
+        specifier: ~4.0.3
         version: 4.0.22(react@18.3.1)(zod@3.23.8)
       dotenv:
         specifier: ^16.4.5
@@ -1311,7 +1344,7 @@ importers:
         version: 1.0.4
       zod-to-json-schema:
         specifier: 'catalog:'
-        version: 3.23.5(zod@3.24.2)
+        version: 3.23.5(zod@3.25.76)
 
   packages/adapters/vercel-ai:
     dependencies:
@@ -1499,6 +1532,31 @@ importers:
         specifier: 'catalog:'
         version: 3.23.8
 
+  packages/plugins/boson:
+    dependencies:
+      '@bosonprotocol/agentic-commerce':
+        specifier: ^1.2.4
+        version: 1.2.4(bufferutil@4.0.9)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)
+      '@goat-sdk/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@goat-sdk/wallet-evm':
+        specifier: workspace:*
+        version: link:../../wallets/evm
+      viem:
+        specifier: 'catalog:'
+        version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
+    devDependencies:
+      '@swc/core':
+        specifier: 1.10.1
+        version: 1.10.1(@swc/helpers@0.5.17)
+      unplugin-swc:
+        specifier: ^1.5.9
+        version: 1.5.9(@swc/core@1.10.1(@swc/helpers@0.5.17))(rollup@4.40.2)
+
   packages/plugins/coingecko:
     dependencies:
       '@goat-sdk/core':
@@ -1646,7 +1704,7 @@ importers:
         version: 16.5.0
       dpsn-client:
         specifier: 1.0.9
-        version: 1.0.9(bufferutil@4.0.9)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+        version: 1.0.9(bufferutil@4.0.9)(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       zod:
         specifier: 'catalog:'
         version: 3.23.8
@@ -2561,7 +2619,7 @@ importers:
         version: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       viem:
         specifier: 'catalog:'
-        version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
+        version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     devDependencies:
       '@lit-protocol/types':
         specifier: 'catalog:'
@@ -2667,7 +2725,7 @@ importers:
         version: link:../evm
       viem:
         specifier: 'catalog:'
-        version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
+        version: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   packages/wallets/zetrix:
     dependencies:
@@ -2760,6 +2818,12 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/anthropic@1.2.12':
+    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
   '@ai-sdk/google-vertex@0.0.43':
     resolution: {integrity: sha512-lmZukH74m6MUl4fbyfz3T4qs5ukDUJ6YB5Dedtu+aK+Mdp05k9qTHAXxWiB8i/VdZqWlS+DEo/+b7pOPX0V7wA==}
     engines: {node: '>=18'}
@@ -2848,6 +2912,12 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
   '@ai-sdk/provider@0.0.24':
     resolution: {integrity: sha512-XMsNGJdGO+L0cxhhegtqZ8+T6nn4EoShS819OvCgI2kLbYTIvk0GWFGD0AXJmxkxs3DrpsJxKAFukFR7bvTkgQ==}
     engines: {node: '>=18'}
@@ -2870,6 +2940,10 @@ packages:
 
   '@ai-sdk/provider@1.1.2':
     resolution: {integrity: sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@0.0.70':
@@ -2905,6 +2979,16 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+      zod:
+        optional: true
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
       zod:
         optional: true
 
@@ -2962,6 +3046,12 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@ai-sdk/ui-utils@1.2.7':
     resolution: {integrity: sha512-OVRxa4SDj0wVsMZ8tGr/whT89oqNtNoXBKmqWC2BRv5ZG6azL2LYZ5ZK35u3lb4l1IE7cWGsLlmq0py0ttsL7A==}
@@ -4289,6 +4379,40 @@ packages:
     peerDependencies:
       '@solana/web3.js': ^1.87.3
 
+  '@bosonprotocol/agentic-commerce@1.2.4':
+    resolution: {integrity: sha512-i1SooJydzf7JNQ4rarRsY0rMzgLTvHfUBZibDlN9ymin5QVxe0GM+Drs5eSaMTuI7zPURGX3Do9+7Z/bwvhwqQ==}
+    engines: {node: '>=20.12.2'}
+    hasBin: true
+
+  '@bosonprotocol/common@1.32.2':
+    resolution: {integrity: sha512-SXaUvMIEHT1yGxcTNlbxoWzyPUqoacrKSIYXpIUJVVOU/5uLYrojULx2htZlqF5OKl6XDxXHSPLyjUxuIEe5lg==}
+
+  '@bosonprotocol/common@1.32.2-alpha.0':
+    resolution: {integrity: sha512-BBeUMpDKAlAwe7CIlF8skj+bRwFrEQFdC9UBEqNm1TtvJhfejnZA6gRyvER9tZyHS4YLXNBZkvBSTY6FoxB9zw==}
+
+  '@bosonprotocol/core-sdk@1.46.1':
+    resolution: {integrity: sha512-T8DlfmWJNrD5vAosvjoZcvEiRWRj81NQRGQtStpEOAVHycsbHAO3zuiHK8Csz4yYeitzHZKMauLUP58Xef3p1g==}
+
+  '@bosonprotocol/core-sdk@1.47.0-alpha.5':
+    resolution: {integrity: sha512-/WPRyZAgiXb1I8OtycuX1kbFQw82r5JX/481cQE8Sy4k+2ci7cC8JKcjnSu2asbStE0QyaHyicVNLlliVbX7Vg==}
+
+  '@bosonprotocol/ethers-sdk@1.17.2-alpha.0':
+    resolution: {integrity: sha512-YEkm68D1nm26f8gtgyUzkMWeVuOqqJrhGFSlDl823pwvK3o6vqyHeiTfYkLMu7hNHF317iCFuIUzr+1SKLYD9A==}
+    peerDependencies:
+      ethers: ^5.5.0
+
+  '@bosonprotocol/ipfs-storage@1.13.0-alpha.6':
+    resolution: {integrity: sha512-5gsFYoDlLs7+qUFn+GhnJe4FpYAvbQZ26RrInboMI37iL72WVunTrRTOqw7ezOkDFrwlgdYRF0UdbarAejxzpQ==}
+
+  '@bosonprotocol/metadata-storage@1.0.1':
+    resolution: {integrity: sha512-f2W2SQAvY5IKD6L9JwaiNye7gGRIIPd/HOB0i+otWLzMPBlwQtbN4JeWSuKeJvuaqu8tyMy7CHzN8EkhrJDB+A==}
+
+  '@bosonprotocol/metadata@1.16.3':
+    resolution: {integrity: sha512-9SDhtoq2DwrRiGvT4MDfHO9rU6iNE961rldbwbVAXOjwqGa/wpKiASE37Ip68hr5GZ/Da07Db4OqQsYDHuz3Rw==}
+
+  '@bosonprotocol/metadata@1.16.3-alpha.22':
+    resolution: {integrity: sha512-qyOkph2mbxv9Bkd6KdOIDov2ghrEIiYsfP8+381p16F75s4kj6l2DMA9YjfXhQOc/1KdPpuAAlquEOhsUz8JjA==}
+
   '@chain-registry/types@0.50.50':
     resolution: {integrity: sha512-H+sGuL8HTr0iFO4PJlBC9MLfrFR+NsD6sFSoFh2+4+obBCVuc3tp5tz/CSfLy04tIySgLlbmqMxkMNkgv1ZpXg==}
 
@@ -4553,6 +4677,9 @@ packages:
   '@discoveryjs/json-ext@0.6.3':
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
     engines: {node: '>=14.17.0'}
+
+  '@dmitryrechkin/json-schema-to-zod@1.0.1':
+    resolution: {integrity: sha512-cG9gC4NMu/7JZqmRZy6uIb+l+kxek2GFQ0/qrhw7xeFK2l5B9yF9FVuujoqFPLRGDHNFYqtBWht7hY4KB0ngrA==}
 
   '@dynamic-labs/assert-package-version@4.0.0-alpha.45':
     resolution: {integrity: sha512-HBadqi9Z36pPBoTS4qhufrwagj8Ysg5lnpuytmiRUmdakf0zq5iY02h6+sebU3bTA/nPx1wCyX2KVyC3aU+33A==}
@@ -5511,6 +5638,15 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
+  '@fermionprotocol/common@1.7.0':
+    resolution: {integrity: sha512-XeOZzC/yqkxH8Xn5CrXBAQEgfFn/wJzm0cexSLFXybviQaUzYQUFJ3LqKZUUO1F/DwwfEHGpSmUBK9k+7jtw4g==}
+
+  '@fermionprotocol/core-sdk@1.7.0':
+    resolution: {integrity: sha512-KmMPiKfdsoZR2rP72tmut6YhevedVKPFn/GXJIUjL4fNWcgL5yB92wO6gB9vOX7w4WAzHvxiRkHmwfk2ZCVxog==}
+
+  '@fermionprotocol/metadata@1.5.2':
+    resolution: {integrity: sha512-c7xYRZ5cOMnpsVmMjmkTV4nLgUDNL20VwxTYH/dLjpgPJE91pLms+JOTUmQKxov7BOa8ywZgcgQl9ocJzwOT7A==}
+
   '@fuel-ts/abi-coder@0.97.2':
     resolution: {integrity: sha512-YbXFwBtQSfGNhIv+mrgr6EbbyVjzc5DwNjVJuC8DDObiAYhow0uzn/URHFdQ8bexokrKBrdzQKDjnAP6F7ap+w==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
@@ -6130,6 +6266,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ipld/dag-cbor@6.0.15':
+    resolution: {integrity: sha512-Vm3VTSTwlmGV92a3C5aeY+r2A18zbH2amehNhsX8PBa3muXICaWrN8Uri85A5hLH7D7ElhE8PdjxD6kNqUmTZA==}
+
+  '@ipld/dag-cbor@7.0.3':
+    resolution: {integrity: sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==}
+
+  '@ipld/dag-json@8.0.11':
+    resolution: {integrity: sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==}
+
+  '@ipld/dag-pb@2.1.18':
+    resolution: {integrity: sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==}
+
   '@irys/arweave@0.0.2':
     resolution: {integrity: sha512-ddE5h4qXbl0xfGlxrtBIwzflaxZUDlDs43TuT0u1OMfyobHul4AA1VEX72Rpzw2bOh4vzoytSqA1jCM7x9YtHg==}
 
@@ -6246,6 +6394,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -6831,6 +6982,10 @@ packages:
   '@modelcontextprotocol/sdk@1.0.4':
     resolution: {integrity: sha512-C+jw1lF6HSGzs7EZpzHbXfzz9rj9him4BaoumlTciW/IDDgIpweF/qiCWKlP02QKg5PPcgY6xY2WCt5y2tpYow==}
 
+  '@modelcontextprotocol/sdk@1.17.4':
+    resolution: {integrity: sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==}
+    engines: {node: '>=18'}
+
   '@modelcontextprotocol/sdk@1.6.0':
     resolution: {integrity: sha512-585s8g+jzuGBomzgzDeP5l8gEyiSs+KhoAHbA2ZZ24Zgm83IZsyCLl/fmWhPHbfYsuLG8NE6SWGZA5ZBql8jSw==}
     engines: {node: '>=18'}
@@ -7053,6 +7208,14 @@ packages:
 
   '@openagenda/verror@3.1.4':
     resolution: {integrity: sha512-+V7QuD6v5sMWez7cu+5DXoXMim+iQssOcspoNgbWDW8sEyC54Mdo5VuIkcIjqhPmQYOzBWo5qlbzNGEpD6PzMA==}
+
+  '@opensea/seaport-js@4.0.4':
+    resolution: {integrity: sha512-pOBgU+y1H9Bh463ZdgFshFBxnBQvEaGfoOJFDHbkvZTNLSqIOyuDmICFTQJEiPjYsS6tMQTbw2oJBtcVLFUT2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@opensea/seaport-js@4.1.2':
+    resolution: {integrity: sha512-UFJ5f/4gqQEvRjjOJJhammWkOeOaXz8trxhquhzcbcqCNScR4+4MSLiSiBA5G7U89F8wN68B3F6AL5XUQTXYcg==}
+    engines: {node: '>=20.0.0'}
 
   '@opentelemetry/api-logs@0.54.2':
     resolution: {integrity: sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==}
@@ -7950,6 +8113,15 @@ packages:
 
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -9101,9 +9273,6 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
-  '@swc/types@0.1.17':
-    resolution: {integrity: sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==}
-
   '@swc/types@0.1.19':
     resolution: {integrity: sha512-WkAZaAfj44kh/UFdAQcrMP1I0nwRqpt27u+08LMBYMqmQfwwMofYoMh/48NGkMMRfC4ynpfwRbJuu8ErfNloeA==}
 
@@ -9292,6 +9461,9 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/minimatch@3.0.5':
+    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
@@ -9876,6 +10048,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
 
@@ -9942,6 +10119,16 @@ packages:
       zod:
         optional: true
 
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   ai@4.3.5:
     resolution: {integrity: sha512-hxJ+6YCdGOK1MVPGITmz1if+LXR/aW72w8TI8kiV+3R7lpK1hfpApR8EjqN2ag6cWa0R7OEI3gb/srWkQ3hT2Q==}
     engines: {node: '>=18'}
@@ -9950,6 +10137,14 @@ packages:
       zod: ^3.23.8
     peerDependenciesMeta:
       react:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
         optional: true
 
   ajv@6.12.6:
@@ -10022,6 +10217,9 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  any-signal@3.0.1:
+    resolution: {integrity: sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -10254,6 +10452,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.5.1:
     resolution: {integrity: sha512-Bw2PgKSrZ3uCuSV9WQ998c/GTJTd+9bWj97n7aDQMP8dP/exAZQlJeswPty0ISy+HZD+9Ex+C7CCnc9Q5QJFmQ==}
 
@@ -10343,6 +10545,9 @@ packages:
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
 
+  blob-to-it@1.0.4:
+    resolution: {integrity: sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==}
+
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
@@ -10391,6 +10596,10 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
     engines: {node: '>=0.10.0'}
@@ -10404,6 +10613,9 @@ packages:
 
   brotli@1.3.3:
     resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browser-readablestream-to-it@1.0.3:
+    resolution: {integrity: sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==}
 
   browserify-aes@1.2.0:
     resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
@@ -10614,6 +10826,10 @@ packages:
   cbor-web@9.0.2:
     resolution: {integrity: sha512-N6gU2GsJS8RR5gy1d9wQcSPgn9FGJFY7KNvdDRlwHfz6kCxrQr2TDnrjXHmr6TFSl6Fd0FC4zRnityEldjRGvQ==}
     engines: {node: '>=16'}
+
+  cborg@1.10.2:
+    resolution: {integrity: sha512-b3tFPA9pUr2zCUiCfRd2+wok2/LBSNUMKOuRRok+WlvvAgEt/PlbgPTsZUcwCOs53IJvLgTp0eotwtosE6njug==}
+    hasBin: true
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -11084,9 +11300,16 @@ packages:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
     engines: {node: '>=0.12'}
 
+  dag-jose@1.0.0:
+    resolution: {integrity: sha512-U0b/YsIPBp6YZNTFrVjwLZAlY3qGRxZTIEcM/CcQmrVrCWq9MWQq9pheXVSPLIhF4SNwzp2SikPva4/BIrJY+g==}
+
   dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
+
+  dashify@2.0.0:
+    resolution: {integrity: sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==}
+    engines: {node: '>=4'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -11353,6 +11576,9 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dns-over-http-resolver@1.2.3:
+    resolution: {integrity: sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -11505,6 +11731,10 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-fetch@1.9.1:
+    resolution: {integrity: sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==}
+    engines: {node: '>=6'}
+
   electron-to-chromium@1.5.152:
     resolution: {integrity: sha512-xBOfg/EBaIlVsHipHl2VdTPJRSvErNUaqW8ejTq5OlOlIYx1wOllCHsAvAIrr55jD1IYEfdR86miUEt8H5IeJg==}
 
@@ -11586,6 +11816,9 @@ packages:
     resolution: {integrity: sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  err-code@3.0.1:
+    resolution: {integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==}
 
   err@1.1.1:
     resolution: {integrity: sha512-N97Ybd2jJHVQ+Ft3Q5+C2gM3kgygkdeQmEqbN2z15UTVyyEsIwLA1VK39O1DHEJhXbwIFcJLqm6iARNhFANcQA==}
@@ -11762,6 +11995,10 @@ packages:
     resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
     engines: {node: '>=14.0.0'}
 
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
+
   ethers@6.7.0:
     resolution: {integrity: sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==}
     engines: {node: '>=14.0.0'}
@@ -11888,6 +12125,10 @@ packages:
   extglob@2.0.4:
     resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
     engines: {node: '>=0.10.0'}
+
+  extract-files@9.0.0:
+    resolution: {integrity: sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==}
+    engines: {node: ^10.17.0 || ^12.0.0 || >= 13.7.0}
 
   extsprintf@1.3.0:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
@@ -12100,6 +12341,10 @@ packages:
     resolution: {integrity: sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==}
     engines: {node: '>= 0.12'}
 
+  form-data@3.0.4:
+    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
+    engines: {node: '>= 6'}
+
   form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -12235,6 +12480,9 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-iterator@1.0.2:
+    resolution: {integrity: sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -12391,6 +12639,11 @@ packages:
   graphemesplit@2.4.4:
     resolution: {integrity: sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==}
 
+  graphql-request@4.3.0:
+    resolution: {integrity: sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==}
+    peerDependencies:
+      graphql: 14 - 16
+
   graphql-request@6.1.0:
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
     peerDependencies:
@@ -12440,6 +12693,10 @@ packages:
     resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
     engines: {node: '>=6'}
     deprecated: this library is no longer supported
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -12689,6 +12946,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore-by-default@1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+
   ignore@4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
@@ -12738,6 +12998,12 @@ packages:
     resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
     engines: {node: '>=12.0.0'}
 
+  interface-datastore@6.1.1:
+    resolution: {integrity: sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==}
+
+  interface-store@2.0.2:
+    resolution: {integrity: sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -12756,6 +13022,27 @@ packages:
   ipaddr.js@2.2.0:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
     engines: {node: '>= 10'}
+
+  ipfs-core-types@0.10.3:
+    resolution: {integrity: sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==}
+    deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
+
+  ipfs-core-utils@0.14.3:
+    resolution: {integrity: sha512-aBkewVhgAj3NWXPwu6imj0wADGiGVZmJzqKzODOJsibDjkx6FGdMv8kvvqtLnK8LS/dvSk9yk32IDtuDyYoV7Q==}
+    deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
+
+  ipfs-http-client@56.0.3:
+    resolution: {integrity: sha512-E3L5ylVl6BjyRUsNehvfuRBYp1hj8vQ8in4zskVPMNzXs6JiCFUbif5a6BtcAlSK4xPQyJCeLNNAWLUeFQTLNA==}
+    engines: {node: '>=15.0.0', npm: '>=3.0.0'}
+    deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
+
+  ipfs-unixfs@6.0.9:
+    resolution: {integrity: sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  ipfs-utils@9.0.14:
+    resolution: {integrity: sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -12813,6 +13100,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -12860,6 +13150,10 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-ip@3.1.0:
+    resolution: {integrity: sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==}
+    engines: {node: '>=8'}
+
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
@@ -12874,6 +13168,10 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -12970,6 +13268,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iso-url@1.2.1:
+    resolution: {integrity: sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==}
+    engines: {node: '>=12'}
+
   isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
     engines: {node: '>=0.10.0'}
@@ -13030,6 +13332,27 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
+
+  it-all@1.0.6:
+    resolution: {integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==}
+
+  it-first@1.0.7:
+    resolution: {integrity: sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==}
+
+  it-glob@1.0.2:
+    resolution: {integrity: sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==}
+
+  it-last@1.0.6:
+    resolution: {integrity: sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==}
+
+  it-map@1.0.6:
+    resolution: {integrity: sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==}
+
+  it-peekable@1.0.3:
+    resolution: {integrity: sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==}
+
+  it-to-stream@1.0.0:
+    resolution: {integrity: sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==}
 
   iterate-object@1.3.4:
     resolution: {integrity: sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw==}
@@ -13898,6 +14221,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mcp-inspector@1.0.0:
+    resolution: {integrity: sha512-oqiKXk2bYGT2Y+YONA0SgbAOsqewmEUyecjFNX8BHMfTWaHZ0QNoGMKCZj7r4+JdzaeHMNdmUdKdRFhApDbunQ==}
+
   md-utils-ts@2.0.0:
     resolution: {integrity: sha512-sMG6JtX0ebcRMHxYTcmgsh0/m6o8hGdQHFE2OgjvflRZlQM51CGGj/uuk056D+12BlCiW0aTpt/AdlDNtgQiew==}
 
@@ -13928,6 +14254,10 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge-options@3.0.4:
+    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
+    engines: {node: '>=10'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -13942,6 +14272,14 @@ packages:
 
   merkletreejs@0.3.11:
     resolution: {integrity: sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==}
+    engines: {node: '>= 7.6.0'}
+
+  merkletreejs@0.4.1:
+    resolution: {integrity: sha512-W2VSHeGTdAnWtedee+pgGn7SHvncMdINnMeHAaXrfarSaMNLff/pm7RCr/QXYxN6XzJFgJZY+28ejO0lAosW4A==}
+    engines: {node: '>= 7.6.0'}
+
+  merkletreejs@0.6.0:
+    resolution: {integrity: sha512-cyiratjG7fyHsa4DVfYVPxcoAh3zmUuOPItIfZex8f0pUVptNEmiiTOoeS0JnDDTWy+n3FKnI0K1gCzti7rGMg==}
     engines: {node: '>= 7.6.0'}
 
   methods@1.1.2:
@@ -14096,6 +14434,10 @@ packages:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -14236,6 +14578,14 @@ packages:
     resolution: {integrity: sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==}
     engines: {node: '>=12.13'}
 
+  multiaddr-to-uri@8.0.0:
+    resolution: {integrity: sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==}
+    deprecated: This module is deprecated, please upgrade to @multiformats/multiaddr-to-uri
+
+  multiaddr@10.0.1:
+    resolution: {integrity: sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==}
+    deprecated: This module is deprecated, please upgrade to @multiformats/multiaddr
+
   multibase@0.6.1:
     resolution: {integrity: sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==}
     deprecated: This module has been superseded by the multiformats module
@@ -14309,6 +14659,11 @@ packages:
 
   napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
+
+  native-fetch@3.0.0:
+    resolution: {integrity: sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==}
+    peerDependencies:
+      node-fetch: '*'
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -14451,6 +14806,11 @@ packages:
   node-stream-zip@1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
+
+  nodemon@3.1.14:
+    resolution: {integrity: sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   noop6@1.0.9:
     resolution: {integrity: sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA==}
@@ -14675,6 +15035,11 @@ packages:
   opengradient-sdk@1.0.0:
     resolution: {integrity: sha512-A1taKP3YzBX2hqqQbpNOqJd4m0Cl4kt+PIvhW63ZYi4BLCHoEcU1HiAtjJHtRtCIggnwcmxRkeaBKBAMGHQDew==}
 
+  opensea-js@7.4.0:
+    resolution: {integrity: sha512-jHg84OO6Rt1OEOQjQk0b+KoDktWtTsZIpi6p09xRzKupWlAlCO8D3qMqKjNDYQaIbstJNi6z1DQAqx+wzxvfIw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: This package has been renamed to @opensea/sdk. Install @opensea/sdk instead.
+
   optimism@0.18.1:
     resolution: {integrity: sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==}
 
@@ -14723,6 +15088,13 @@ packages:
   p-cancelable@3.0.0:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
     engines: {node: '>=12.20'}
+
+  p-defer@3.0.0:
+    resolution: {integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==}
+    engines: {node: '>=8'}
+
+  p-fifo@1.0.0:
+    resolution: {integrity: sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -14807,6 +15179,9 @@ packages:
   parse-asn1@5.1.7:
     resolution: {integrity: sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==}
     engines: {node: '>= 0.10'}
+
+  parse-duration@1.1.2:
+    resolution: {integrity: sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==}
 
   parse-headers@2.0.5:
     resolution: {integrity: sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==}
@@ -14955,6 +15330,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -15009,6 +15388,10 @@ packages:
 
   pkce-challenge@4.1.0:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
+    engines: {node: '>=16.20.0'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
   pkg-dir@3.0.0:
@@ -15272,6 +15655,9 @@ packages:
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
+  pstree.remy@1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
@@ -15470,6 +15856,9 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-native-fetch-api@3.0.0:
+    resolution: {integrity: sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==}
+
   react-native-get-random-values@1.11.0:
     resolution: {integrity: sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==}
     peerDependencies:
@@ -15566,6 +15955,13 @@ packages:
   recast@0.21.5:
     resolution: {integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==}
     engines: {node: '>= 4'}
+
+  receptacle@1.3.2:
+    resolution: {integrity: sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==}
+
+  reconnecting-eventsource@1.6.5:
+    resolution: {integrity: sha512-L7ADnbp7yA42vvjwx7cZFNmiyHNBu/UldL1NCEvB23xBkZhESF83s2cnD9sLfvcX9wMIzW1UpIS7EOq/iu3E2g==}
+    engines: {node: '>=12.0.0'}
 
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
@@ -15733,6 +16129,9 @@ packages:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
 
+  retimer@3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
+
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
@@ -15853,6 +16252,12 @@ packages:
 
   scheduler@0.24.0-canary-efb381bbf-20230505:
     resolution: {integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==}
+
+  schema-to-yup@1.11.15:
+    resolution: {integrity: sha512-NBESoKQKK2f7zmrUb2z9M5cOoikn7AJxFn5OVxBTyBFXmh9Gw13x8O/xHkh2iDOaD/rPI+pdvNAt6DsqIwu9OQ==}
+
+  schema-to-yup@1.12.18:
+    resolution: {integrity: sha512-rzMtnIQpkokOzyb6JfsuCB+/BklFB5J7pFcvc/SnybOtmks8uW4SJXfMpzMQT98f826XgI3/mlPGQf0HBhF8FQ==}
 
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
@@ -16042,6 +16447,10 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -16249,12 +16658,18 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
+  stream-to-it@0.2.4:
+    resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
   streamx@2.21.1:
     resolution: {integrity: sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==}
+
+  strict-event-emitter-types@2.0.0:
+    resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
 
   strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
@@ -16367,6 +16782,10 @@ packages:
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
+
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -16521,6 +16940,9 @@ packages:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
     engines: {node: '>=0.10.0'}
 
+  timeout-abort-controller@3.0.0:
+    resolution: {integrity: sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==}
+
   tiny-case@1.0.3:
     resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
 
@@ -16620,6 +17042,10 @@ packages:
 
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
+
+  touch@3.1.1:
+    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
+    hasBin: true
 
   tough-cookie@2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
@@ -16877,6 +17303,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undefsafe@2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
+
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
@@ -16934,6 +17363,9 @@ packages:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
     engines: {node: '>=0.10.0'}
 
+  uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
+
   unique-names-generator@4.7.1:
     resolution: {integrity: sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==}
     engines: {node: '>=8'}
@@ -16976,8 +17408,17 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-swc@1.5.9:
+    resolution: {integrity: sha512-RKwK3yf0M+MN17xZfF14bdKqfx0zMXYdtOdxLiE6jHAoidupKq3jGdJYANyIM1X/VmABhh1WpdO+/f4+Ol89+g==}
+    peerDependencies:
+      '@swc/core': ^1.2.108
+
   unplugin-utils@0.2.4:
     resolution: {integrity: sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==}
+    engines: {node: '>=18.12.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
   unset-value@1.0.0:
@@ -17064,6 +17505,10 @@ packages:
 
   upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
+
+  uppercamelcase@3.0.0:
+    resolution: {integrity: sha512-zTWmRiOJACCdFGWjzye3L5cjSuVdZ/c8C0iHIwVbfORFD8IhGNAO6BOWkZ+fj+SI6/aFbdjGXE6gwPG780H4gQ==}
+    engines: {node: '>=4'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -17211,6 +17656,9 @@ packages:
 
   varint@5.0.2:
     resolution: {integrity: sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==}
+
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -17570,6 +18018,9 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   websocket@1.0.35:
     resolution: {integrity: sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==}
     engines: {node: '>=4.0.0'}
@@ -17899,6 +18350,9 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
     engines: {node: '>=12.20.0'}
@@ -17952,6 +18406,12 @@ snapshots:
       '@ai-sdk/provider': 0.0.26
       '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
       zod: 3.23.8
+
+  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/google-vertex@0.0.43(@google-cloud/vertexai@1.9.0(encoding@0.1.13))(zod@3.23.8)':
     dependencies:
@@ -18035,13 +18495,6 @@ snapshots:
     optionalDependencies:
       zod: 3.23.8
 
-  '@ai-sdk/provider-utils@2.2.6(zod@3.23.8)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.2
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-      zod: 3.23.8
-
   '@ai-sdk/provider-utils@2.2.6(zod@3.24.1)':
     dependencies:
       '@ai-sdk/provider': 1.1.2
@@ -18055,6 +18508,20 @@ snapshots:
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.24.2
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.23.8)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.23.8
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
 
   '@ai-sdk/provider@0.0.24':
     dependencies:
@@ -18077,6 +18544,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@1.1.2':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -18110,15 +18581,25 @@ snapshots:
       react: 18.3.1
       zod: 3.23.8
 
-  '@ai-sdk/react@1.2.8(react@18.3.1)(zod@3.23.8)':
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@3.23.8)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.6(zod@3.23.8)
-      '@ai-sdk/ui-utils': 1.2.7(zod@3.23.8)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.23.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.23.8)
       react: 18.3.1
       swr: 2.3.3(react@18.3.1)
       throttleit: 2.1.0
     optionalDependencies:
       zod: 3.23.8
+
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      react: 18.3.1
+      swr: 2.3.3(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@ai-sdk/react@1.2.8(react@18.3.1)(zod@3.24.1)':
     dependencies:
@@ -18183,12 +18664,19 @@ snapshots:
     optionalDependencies:
       zod: 3.23.8
 
-  '@ai-sdk/ui-utils@1.2.7(zod@3.23.8)':
+  '@ai-sdk/ui-utils@1.2.11(zod@3.23.8)':
     dependencies:
-      '@ai-sdk/provider': 1.1.2
-      '@ai-sdk/provider-utils': 2.2.6(zod@3.23.8)
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.23.8)
       zod: 3.23.8
       zod-to-json-schema: 3.24.1(zod@3.23.8)
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.1(zod@3.25.76)
 
   '@ai-sdk/ui-utils@1.2.7(zod@3.24.1)':
     dependencies:
@@ -19453,7 +19941,7 @@ snapshots:
       '@babel/traverse': 7.26.7
       '@babel/types': 7.26.7
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19473,7 +19961,7 @@ snapshots:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19541,7 +20029,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -20414,7 +20902,7 @@ snapshots:
       '@babel/parser': 7.27.1
       '@babel/template': 7.25.9
       '@babel/types': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20426,7 +20914,7 @@ snapshots:
       '@babel/parser': 7.27.1
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20549,6 +21037,135 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
+
+  '@bosonprotocol/agentic-commerce@1.2.4(bufferutil@4.0.9)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
+      '@bosonprotocol/common': 1.32.2-alpha.0
+      '@bosonprotocol/core-sdk': 1.47.0-alpha.5(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@bosonprotocol/ethers-sdk': 1.17.2-alpha.0(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@bosonprotocol/ipfs-storage': 1.13.0-alpha.6(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      '@bosonprotocol/metadata': 1.16.3-alpha.22
+      '@dmitryrechkin/json-schema-to-zod': 1.0.1
+      '@ethersproject/bignumber': 5.8.0
+      '@fermionprotocol/common': 1.7.0
+      '@fermionprotocol/core-sdk': 1.7.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@fermionprotocol/metadata': 1.5.2
+      '@goat-sdk/core': 0.5.0(zod@3.25.76)
+      '@goat-sdk/wallet-evm': 0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
+      '@goat-sdk/wallet-viem': 0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(@goat-sdk/wallet-evm@0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10))(viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8))
+      '@modelcontextprotocol/sdk': 1.17.4
+      '@opensea/seaport-js': 4.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ai: 4.3.19(react@18.3.1)(zod@3.25.76)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      commander: 14.0.0
+      dotenv: 16.5.0
+      ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ethers-v6: ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      express: 5.1.0
+      lodash: 4.17.21
+      mcp-inspector: 1.0.0
+      nodemon: 3.1.14
+      reflect-metadata: 0.2.2
+      viem: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - node-fetch
+      - react
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@bosonprotocol/common@1.32.2':
+    dependencies:
+      '@bosonprotocol/metadata': 1.16.3
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/units': 5.7.0
+
+  '@bosonprotocol/common@1.32.2-alpha.0':
+    dependencies:
+      '@bosonprotocol/metadata': 1.16.3
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/units': 5.7.0
+
+  '@bosonprotocol/core-sdk@1.46.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bosonprotocol/common': 1.32.2
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/units': 5.7.0
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      graphql: 16.10.0
+      graphql-request: 4.3.0(encoding@0.1.13)(graphql@16.10.0)
+      mustache: 4.2.0
+      opensea-js: 7.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      schema-to-yup: 1.12.18
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@bosonprotocol/core-sdk@1.47.0-alpha.5(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bosonprotocol/common': 1.32.2
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/address': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/bytes': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/units': 5.7.0
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      graphql: 16.10.0
+      graphql-request: 4.3.0(encoding@0.1.13)(graphql@16.10.0)
+      mustache: 4.2.0
+      opensea-js: 7.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      schema-to-yup: 1.12.18
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@bosonprotocol/ethers-sdk@1.17.2-alpha.0(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@bosonprotocol/common': 1.32.2-alpha.0
+      ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
+  '@bosonprotocol/ipfs-storage@1.13.0-alpha.6(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))':
+    dependencies:
+      '@bosonprotocol/metadata-storage': 1.0.1
+      ipfs-http-client: 56.0.3(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - node-fetch
+      - supports-color
+
+  '@bosonprotocol/metadata-storage@1.0.1': {}
+
+  '@bosonprotocol/metadata@1.16.3':
+    dependencies:
+      '@bosonprotocol/metadata-storage': 1.0.1
+      schema-to-yup: 1.12.18
+      yup: 1.6.1
+
+  '@bosonprotocol/metadata@1.16.3-alpha.22':
+    dependencies:
+      '@bosonprotocol/metadata-storage': 1.0.1
+      schema-to-yup: 1.12.18
+      yup: 1.6.1
 
   '@chain-registry/types@0.50.50': {}
 
@@ -20900,7 +21517,7 @@ snapshots:
       '@cosmjs/encoding': 0.33.0
       '@cosmjs/math': 0.33.0
       '@cosmjs/utils': 0.33.0
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
       bn.js: 5.2.1
       elliptic: 6.6.1
       libsodium-wrappers-sumo: 0.7.15
@@ -21155,6 +21772,10 @@ snapshots:
       - utf-8-validate
 
   '@discoveryjs/json-ext@0.6.3': {}
+
+  '@dmitryrechkin/json-schema-to-zod@1.0.1':
+    dependencies:
+      zod: 3.24.1
 
   '@dynamic-labs/assert-package-version@4.0.0-alpha.45(eventemitter3@5.0.1)':
     dependencies:
@@ -22410,6 +23031,38 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@fermionprotocol/common@1.7.0':
+    dependencies:
+      '@bosonprotocol/common': 1.32.2
+      '@ethersproject/units': 5.7.0
+
+  '@fermionprotocol/core-sdk@1.7.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bosonprotocol/common': 1.32.2
+      '@bosonprotocol/core-sdk': 1.46.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@ethersproject/abi': 5.8.0
+      '@ethersproject/bignumber': 5.8.0
+      '@ethersproject/constants': 5.8.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@fermionprotocol/common': 1.7.0
+      '@fermionprotocol/metadata': 1.5.2
+      cross-fetch: 4.1.0(encoding@0.1.13)
+      graphql: 16.10.0
+      graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.10.0)
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@fermionprotocol/metadata@1.5.2':
+    dependencies:
+      '@bosonprotocol/metadata': 1.16.3
+      '@bosonprotocol/metadata-storage': 1.0.1
+      '@fermionprotocol/common': 1.7.0
+      ajv: 8.17.1
+      schema-to-yup: 1.11.15
+
   '@fuel-ts/abi-coder@0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))':
     dependencies:
       '@fuel-ts/crypto': 0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))
@@ -22451,7 +23104,7 @@ snapshots:
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))
       '@fuel-ts/versions': 0.97.2
       '@fuels/vm-asm': 0.58.2
-      '@noble/curves': 1.8.1
+      '@noble/curves': 1.8.2
       events: 3.3.0
       graphql: 16.10.0
       graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.10.0)
@@ -22467,7 +23120,7 @@ snapshots:
       '@fuel-ts/errors': 0.97.2
       '@fuel-ts/interfaces': 0.97.2
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
       bech32: 2.0.0
     transitivePeerDependencies:
       - vitest
@@ -22498,7 +23151,7 @@ snapshots:
       '@fuel-ts/interfaces': 0.97.2
       '@fuel-ts/math': 0.97.2
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
     transitivePeerDependencies:
       - vitest
 
@@ -22511,7 +23164,7 @@ snapshots:
       '@fuel-ts/crypto': 0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))
       '@fuel-ts/interfaces': 0.97.2
       '@fuel-ts/utils': 0.97.2(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0))
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
     transitivePeerDependencies:
       - vitest
 
@@ -22631,10 +23284,10 @@ snapshots:
       '@langchain/core': 0.3.6(openai@4.77.3(encoding@0.1.13)(zod@3.24.1))
       zod: 3.24.1
 
-  '@goat-sdk/adapter-mastra@0.1.0(@goat-sdk/core@0.4.9(zod@3.23.8))(ai@4.3.5(react@18.3.1)(zod@3.23.8))(zod@3.23.8)':
+  '@goat-sdk/adapter-mastra@0.1.0(@goat-sdk/core@0.4.9(zod@3.23.8))(ai@4.3.19(react@18.3.1)(zod@3.23.8))(zod@3.23.8)':
     dependencies:
       '@goat-sdk/core': 0.4.9(zod@3.23.8)
-      ai: 4.3.5(react@18.3.1)(zod@3.23.8)
+      ai: 4.3.19(react@18.3.1)(zod@3.23.8)
       zod: 3.23.8
 
   '@goat-sdk/adapter-model-context-protocol@0.2.11(@goat-sdk/core@0.4.9(zod@3.23.8))(@modelcontextprotocol/sdk@1.0.4)(zod@3.23.8)':
@@ -22677,6 +23330,12 @@ snapshots:
       ai: 4.0.3(react@18.3.1)(zod@3.23.8)
       zod: 3.23.8
 
+  '@goat-sdk/adapter-vercel-ai@0.2.10(@goat-sdk/core@packages+core)(ai@4.0.22(react@18.3.1)(zod@3.23.8))(zod@3.23.8)':
+    dependencies:
+      '@goat-sdk/core': link:packages/core
+      ai: 4.0.22(react@18.3.1)(zod@3.23.8)
+      zod: 3.23.8
+
   '@goat-sdk/adapter-vercel-ai@0.2.9(@goat-sdk/core@0.4.8(zod@3.23.8))(ai@4.0.22(react@18.3.1)(zod@3.23.8))(zod@3.23.8)':
     dependencies:
       '@goat-sdk/core': 0.4.8(zod@3.23.8)
@@ -22697,6 +23356,11 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
       zod: 3.23.8
+
+  '@goat-sdk/core@0.5.0(zod@3.25.76)':
+    dependencies:
+      reflect-metadata: 0.2.2
+      zod: 3.25.76
 
   '@goat-sdk/crossmint@0.4.5(@goat-sdk/core@0.4.9(zod@3.23.8))(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10)':
     dependencies:
@@ -22955,6 +23619,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@goat-sdk/wallet-evm@0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@goat-sdk/core': 0.5.0(zod@3.25.76)
+      abitype: 1.0.8(typescript@5.8.2)(zod@3.23.8)
+      viem: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   '@goat-sdk/wallet-fuel@0.1.9(@goat-sdk/core@0.4.9(zod@3.23.8))(fuels@0.97.2(encoding@0.1.13)(vitest@2.1.9(@types/node@22.13.13)(terser@5.37.0)))':
     dependencies:
       '@goat-sdk/core': 0.4.9(zod@3.23.8)
@@ -23117,10 +23792,21 @@ snapshots:
       '@goat-sdk/wallet-evm': link:packages/wallets/evm
       viem: 2.23.2(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
 
+  '@goat-sdk/wallet-viem@0.2.12(@goat-sdk/wallet-evm@packages+wallets+evm)(viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8))':
+    dependencies:
+      '@goat-sdk/wallet-evm': link:packages/wallets/evm
+      viem: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+
   '@goat-sdk/wallet-viem@0.3.0(@goat-sdk/core@0.5.0(zod@3.23.8))(@goat-sdk/wallet-evm@0.3.0(@goat-sdk/core@0.5.0(zod@3.23.8))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10))(viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8))':
     dependencies:
       '@goat-sdk/core': 0.5.0(zod@3.23.8)
       '@goat-sdk/wallet-evm': 0.3.0(@goat-sdk/core@0.5.0(zod@3.23.8))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
+      viem: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+
+  '@goat-sdk/wallet-viem@0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(@goat-sdk/wallet-evm@0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10))(viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8))':
+    dependencies:
+      '@goat-sdk/core': 0.5.0(zod@3.25.76)
+      '@goat-sdk/wallet-evm': 0.3.0(@goat-sdk/core@0.5.0(zod@3.25.76))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
       viem: 2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.23.8)
 
   '@goat-sdk/wallet-zetrix@0.1.1(@goat-sdk/core@0.4.8(zod@3.23.8))(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zetrix-sdk-nodejs@1.0.1)':
@@ -23404,6 +24090,25 @@ snapshots:
 
   '@img/sharp-win32-x64@0.33.5':
     optional: true
+
+  '@ipld/dag-cbor@6.0.15':
+    dependencies:
+      cborg: 1.10.2
+      multiformats: 9.9.0
+
+  '@ipld/dag-cbor@7.0.3':
+    dependencies:
+      cborg: 1.10.2
+      multiformats: 9.9.0
+
+  '@ipld/dag-json@8.0.11':
+    dependencies:
+      cborg: 1.10.2
+      multiformats: 9.9.0
+
+  '@ipld/dag-pb@2.1.18':
+    dependencies:
+      multiformats: 9.9.0
 
   '@irys/arweave@0.0.2':
     dependencies:
@@ -23705,6 +24410,11 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -25136,7 +25846,7 @@ snapshots:
       bufferutil: 4.0.9
       cross-fetch: 4.1.0(encoding@0.1.13)
       date-fns: 2.30.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       eciesjs: 0.4.14
       eventemitter2: 6.4.9
       readable-stream: 3.6.2
@@ -25151,7 +25861,7 @@ snapshots:
       bufferutil: 4.0.9
       cross-fetch: 4.1.0(encoding@0.1.13)
       date-fns: 2.30.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       eciesjs: 0.4.14
       eventemitter2: 6.4.9
       readable-stream: 3.6.2
@@ -25182,7 +25892,7 @@ snapshots:
       '@metamask/sdk-install-modal-web': 0.30.0(i18next@23.11.5)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.0(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.18)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)
       bowser: 2.11.0
       cross-fetch: 4.1.0(encoding@0.1.13)
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       eciesjs: 0.4.14
       eth-rpc-errors: 4.0.3
       eventemitter2: 6.4.9
@@ -25216,7 +25926,7 @@ snapshots:
       '@paulmillr/qr': 0.2.1
       bowser: 2.11.0
       cross-fetch: 4.1.0(encoding@0.1.13)
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       eciesjs: 0.4.14
       eth-rpc-errors: 4.0.3
       eventemitter2: 6.4.9
@@ -25239,7 +25949,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       semver: 7.7.1
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -25252,7 +25962,7 @@ snapshots:
       '@noble/hashes': 1.7.2
       '@scure/base': 1.2.4
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.7.1
       uuid: 9.0.1
@@ -25266,7 +25976,7 @@ snapshots:
       '@noble/hashes': 1.7.2
       '@scure/base': 1.2.4
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.7.1
       uuid: 9.0.1
@@ -25441,6 +26151,23 @@ snapshots:
       content-type: 1.0.5
       raw-body: 3.0.0
       zod: 3.24.1
+
+  '@modelcontextprotocol/sdk@1.17.4':
+    dependencies:
+      ajv: 6.12.6
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.1
+      express: 5.1.0
+      express-rate-limit: 7.5.0(express@5.1.0)
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.0
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@modelcontextprotocol/sdk@1.6.0':
     dependencies:
@@ -25668,6 +26395,22 @@ snapshots:
       depd: 2.0.0
       inherits: 2.0.4
       sprintf-js: 1.1.3
+
+  '@opensea/seaport-js@4.0.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      merkletreejs: 0.4.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@opensea/seaport-js@4.1.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      merkletreejs: 0.6.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@opentelemetry/api-logs@0.54.2':
     dependencies:
@@ -27217,6 +27960,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.40.2
 
+  '@rollup/pluginutils@5.3.0(rollup@4.40.2)':
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.40.2
+
   '@rollup/rollup-android-arm-eabi@4.34.9':
     optional: true
 
@@ -27513,8 +28264,8 @@ snapshots:
 
   '@scure/bip32@1.6.2':
     dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/base': 1.2.4
 
   '@scure/bip39@1.3.0':
@@ -27534,7 +28285,7 @@ snapshots:
 
   '@scure/bip39@1.5.4':
     dependencies:
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.7.2
       '@scure/base': 1.2.4
 
   '@scure/starknet@1.0.0':
@@ -28598,8 +29349,8 @@ snapshots:
   '@solana/web3.js@1.92.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.6.0
       bigint-buffer: 1.1.5
@@ -28840,7 +29591,7 @@ snapshots:
   '@swc/core@1.10.1(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.17
+      '@swc/types': 0.1.19
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.10.1
       '@swc/core-darwin-x64': 1.10.1
@@ -28880,10 +29631,6 @@ snapshots:
   '@swc/helpers@0.5.17':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/types@0.1.17':
-    dependencies:
-      '@swc/counter': 0.1.3
 
   '@swc/types@0.1.19':
     dependencies:
@@ -29161,6 +29908,8 @@ snapshots:
       '@types/node': 20.17.11
 
   '@types/mime@1.3.5': {}
+
+  '@types/minimatch@3.0.5': {}
 
   '@types/minimatch@5.1.2': {}
 
@@ -30772,10 +31521,10 @@ snapshots:
       typescript: 5.6.3
       zod: 3.23.8
 
-  abitype@1.0.8(typescript@5.6.3)(zod@3.24.2):
+  abitype@1.0.8(typescript@5.6.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.6.3
-      zod: 3.24.2
+      zod: 3.25.76
 
   abitype@1.0.8(typescript@5.8.2)(zod@3.22.4):
     optionalDependencies:
@@ -30792,10 +31541,10 @@ snapshots:
       typescript: 5.8.2
       zod: 3.24.1
 
-  abitype@1.0.8(typescript@5.8.2)(zod@3.24.2):
+  abitype@1.0.8(typescript@5.8.2)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.8.2
-      zod: 3.24.2
+      zod: 3.25.76
 
   abort-controller-x@0.4.3: {}
 
@@ -30835,6 +31584,8 @@ snapshots:
 
   acorn@8.14.1: {}
 
+  acorn@8.16.0: {}
+
   aes-js@3.0.0: {}
 
   aes-js@3.1.2: {}
@@ -30843,7 +31594,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -30904,15 +31655,27 @@ snapshots:
       react: 18.3.1
       zod: 3.23.8
 
-  ai@4.3.5(react@18.3.1)(zod@3.23.8):
+  ai@4.3.19(react@18.3.1)(zod@3.23.8):
     dependencies:
-      '@ai-sdk/provider': 1.1.2
-      '@ai-sdk/provider-utils': 2.2.6(zod@3.23.8)
-      '@ai-sdk/react': 1.2.8(react@18.3.1)(zod@3.23.8)
-      '@ai-sdk/ui-utils': 1.2.7(zod@3.23.8)
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.23.8)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@3.23.8)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.23.8)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       zod: 3.23.8
+    optionalDependencies:
+      react: 18.3.1
+
+  ai@4.3.19(react@18.3.1)(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
     optionalDependencies:
       react: 18.3.1
 
@@ -30939,6 +31702,10 @@ snapshots:
       zod: 3.24.2
     optionalDependencies:
       react: 18.3.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv@6.12.6:
     dependencies:
@@ -31020,6 +31787,8 @@ snapshots:
       - supports-color
 
   any-promise@1.3.0: {}
+
+  any-signal@3.0.1: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -31288,6 +32057,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.5.1:
     optional: true
 
@@ -31394,6 +32165,10 @@ snapshots:
 
   blakejs@1.2.1: {}
 
+  blob-to-it@1.0.4:
+    dependencies:
+      browser-readablestream-to-it: 1.0.3
+
   bluebird@3.4.7: {}
 
   bluebird@3.7.2: {}
@@ -31427,7 +32202,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -31460,6 +32235,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@2.3.2:
     dependencies:
       arr-flatten: 1.1.0
@@ -31484,6 +32263,8 @@ snapshots:
   brotli@1.3.3:
     dependencies:
       base64-js: 1.5.1
+
+  browser-readablestream-to-it@1.0.3: {}
 
   browserify-aes@1.2.0:
     dependencies:
@@ -31725,6 +32506,8 @@ snapshots:
   caseless@0.12.0: {}
 
   cbor-web@9.0.2: {}
+
+  cborg@1.10.2: {}
 
   ccount@2.0.1: {}
 
@@ -32273,9 +33056,16 @@ snapshots:
       es5-ext: 0.10.64
       type: 2.7.3
 
+  dag-jose@1.0.0:
+    dependencies:
+      '@ipld/dag-cbor': 6.0.15
+      multiformats: 9.9.0
+
   dashdash@1.14.1:
     dependencies:
       assert-plus: 1.0.0
+
+  dashify@2.0.0: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -32307,9 +33097,11 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.4.0:
+  debug@4.4.0(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
 
   decamelize@1.2.0: {}
 
@@ -32479,6 +33271,15 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dns-over-http-resolver@1.2.3(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      debug: 4.4.0(supports-color@5.5.0)
+      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      receptacle: 1.3.2
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -32508,9 +33309,9 @@ snapshots:
 
   dotenv@16.5.0: {}
 
-  dpsn-client@1.0.9(bufferutil@4.0.9)(ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
+  dpsn-client@1.0.9(bufferutil@4.0.9)(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
     dependencies:
-      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       mqtt: 5.11.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       node-fetch: 3.3.2
     transitivePeerDependencies:
@@ -32571,6 +33372,10 @@ snapshots:
       '@noble/hashes': 1.7.2
 
   ee-first@1.1.1: {}
+
+  electron-fetch@1.9.1:
+    dependencies:
+      encoding: 0.1.13
 
   electron-to-chromium@1.5.152: {}
 
@@ -32659,6 +33464,8 @@ snapshots:
   entities@4.5.0: {}
 
   envinfo@7.14.0: {}
+
+  err-code@3.0.1: {}
 
   err@1.1.1:
     dependencies:
@@ -33011,6 +33818,19 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ethers@6.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@adraffy/ens-normalize': 1.9.2
@@ -33169,7 +33989,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -33233,6 +34053,8 @@ snapshots:
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
+
+  extract-files@9.0.0: {}
 
   extsprintf@1.3.0: {}
 
@@ -33396,7 +34218,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -33471,6 +34293,14 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
       safe-buffer: 5.2.1
+
+  form-data@3.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   form-data@4.0.0:
     dependencies:
@@ -33677,6 +34507,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-iterator@1.0.2: {}
 
   get-package-type@0.1.0: {}
 
@@ -33940,6 +34772,15 @@ snapshots:
       js-base64: 3.7.7
       unicode-trie: 2.0.0
 
+  graphql-request@4.3.0(encoding@0.1.13)(graphql@16.10.0):
+    dependencies:
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      extract-files: 9.0.0
+      form-data: 3.0.4
+      graphql: 16.10.0
+    transitivePeerDependencies:
+      - encoding
+
   graphql-request@6.1.0(encoding@0.1.13)(graphql@16.10.0):
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
@@ -34017,6 +34858,8 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       har-schema: 2.0.0
+
+  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -34193,14 +35036,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34223,14 +35066,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34273,6 +35116,8 @@ snapshots:
       punycode: 2.1.0
 
   ieee754@1.2.1: {}
+
+  ignore-by-default@1.0.1: {}
 
   ignore@4.0.6: {}
 
@@ -34334,6 +35179,14 @@ snapshots:
       through: 2.3.8
       wrap-ansi: 6.2.0
 
+  interface-datastore@6.1.1:
+    dependencies:
+      interface-store: 2.0.2
+      nanoid: 3.3.11
+      uint8arrays: 3.1.1
+
+  interface-store@2.0.2: {}
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -34348,6 +35201,95 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.2.0: {}
+
+  ipfs-core-types@0.10.3(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      '@ipld/dag-pb': 2.1.18
+      interface-datastore: 6.1.1
+      ipfs-unixfs: 6.0.9
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
+  ipfs-core-utils@0.14.3(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      any-signal: 3.0.1
+      blob-to-it: 1.0.4
+      browser-readablestream-to-it: 1.0.3
+      debug: 4.4.0(supports-color@5.5.0)
+      err-code: 3.0.1
+      ipfs-core-types: 0.10.3(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-unixfs: 6.0.9
+      ipfs-utils: 9.0.14(encoding@0.1.13)
+      it-all: 1.0.6
+      it-map: 1.0.6
+      it-peekable: 1.0.3
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiaddr-to-uri: 8.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+      nanoid: 3.3.11
+      parse-duration: 1.1.2
+      timeout-abort-controller: 3.0.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - node-fetch
+      - supports-color
+
+  ipfs-http-client@56.0.3(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      '@ipld/dag-cbor': 7.0.3
+      '@ipld/dag-json': 8.0.11
+      '@ipld/dag-pb': 2.1.18
+      any-signal: 3.0.1
+      dag-jose: 1.0.0
+      debug: 4.4.0(supports-color@5.5.0)
+      err-code: 3.0.1
+      ipfs-core-types: 0.10.3(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-core-utils: 0.14.3(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-utils: 9.0.14(encoding@0.1.13)
+      it-first: 1.0.7
+      it-last: 1.0.6
+      merge-options: 3.0.4
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+      parse-duration: 1.1.2
+      stream-to-it: 0.2.4
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - node-fetch
+      - supports-color
+
+  ipfs-unixfs@6.0.9:
+    dependencies:
+      err-code: 3.0.1
+      protobufjs: 6.11.4
+
+  ipfs-utils@9.0.14(encoding@0.1.13):
+    dependencies:
+      any-signal: 3.0.1
+      browser-readablestream-to-it: 1.0.3
+      buffer: 6.0.3
+      electron-fetch: 1.9.1
+      err-code: 3.0.1
+      is-electron: 2.2.2
+      iso-url: 1.2.1
+      it-all: 1.0.6
+      it-glob: 1.0.2
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      nanoid: 3.3.11
+      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      node-fetch: 2.7.0(encoding@0.1.13)
+      react-native-fetch-api: 3.0.0
+      stream-to-it: 0.2.4
+    transitivePeerDependencies:
+      - encoding
 
   iron-webcrypto@1.2.1: {}
 
@@ -34396,6 +35338,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-electron@2.2.2: {}
+
   is-extendable@0.1.1: {}
 
   is-extendable@1.0.1:
@@ -34431,6 +35375,10 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-ip@3.1.0:
+    dependencies:
+      ip-regex: 4.3.0
+
   is-module@1.0.0: {}
 
   is-number@3.0.0:
@@ -34440,6 +35388,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-plain-obj@2.1.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -34520,6 +35470,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iso-url@1.2.1: {}
+
   isobject@2.1.0:
     dependencies:
       isarray: 1.0.0
@@ -34592,7 +35544,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -34602,6 +35554,30 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  it-all@1.0.6: {}
+
+  it-first@1.0.7: {}
+
+  it-glob@1.0.2:
+    dependencies:
+      '@types/minimatch': 3.0.5
+      minimatch: 3.1.2
+
+  it-last@1.0.6: {}
+
+  it-map@1.0.6: {}
+
+  it-peekable@1.0.3: {}
+
+  it-to-stream@1.0.0:
+    dependencies:
+      buffer: 6.0.3
+      fast-fifo: 1.3.2
+      get-iterator: 1.0.2
+      p-defer: 3.0.0
+      p-fifo: 1.0.0
+      readable-stream: 3.6.2
 
   iterate-object@1.3.4: {}
 
@@ -35692,6 +36668,15 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mcp-inspector@1.0.0:
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.17.4
+      reconnecting-eventsource: 1.6.5
+      strict-event-emitter-types: 2.0.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
   md-utils-ts@2.0.0: {}
 
   md5.js@1.3.5:
@@ -35724,6 +36709,10 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  merge-options@3.0.4:
+    dependencies:
+      is-plain-obj: 2.1.0
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -35740,6 +36729,18 @@ snapshots:
       crypto-js: 4.2.0
       treeify: 1.1.0
       web3-utils: 1.10.4
+
+  merkletreejs@0.4.1:
+    dependencies:
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
+
+  merkletreejs@0.6.0:
+    dependencies:
+      buffer-reverse: 1.0.1
+      crypto-js: 4.2.0
+      treeify: 1.1.0
 
   methods@1.1.2: {}
 
@@ -36007,6 +37008,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -36101,7 +37106,7 @@ snapshots:
   mqtt-packet@9.0.2:
     dependencies:
       bl: 6.1.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       process-nextick-args: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -36112,7 +37117,7 @@ snapshots:
       '@types/ws': 8.18.1
       commist: 3.2.0
       concat-stream: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       help-me: 5.0.0
       lru-cache: 10.4.3
       minimist: 1.2.8
@@ -36139,6 +37144,25 @@ snapshots:
   ms@2.1.3: {}
 
   ms@3.0.0-canary.1: {}
+
+  multiaddr-to-uri@8.0.0(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
+  multiaddr@10.0.1(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      dns-over-http-resolver: 1.2.3(node-fetch@2.7.0(encoding@0.1.13))
+      err-code: 3.0.1
+      is-ip: 3.1.0
+      multiformats: 9.9.0
+      uint8arrays: 3.1.1
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
 
   multibase@0.6.1:
     dependencies:
@@ -36216,6 +37240,10 @@ snapshots:
       - supports-color
 
   napi-build-utils@1.0.2: {}
+
+  native-fetch@3.0.0(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
 
   natural-compare@1.4.0: {}
 
@@ -36335,6 +37363,19 @@ snapshots:
 
   node-stream-zip@1.15.0: {}
 
+  nodemon@3.1.14:
+    dependencies:
+      chokidar: 3.6.0
+      debug: 4.4.0(supports-color@5.5.0)
+      ignore-by-default: 1.0.1
+      minimatch: 10.2.5
+      pstree.remy: 1.1.8
+      semver: 7.7.1
+      simple-update-notifier: 2.0.0
+      supports-color: 5.5.0
+      touch: 3.1.1
+      undefsafe: 2.0.5
+
   noop6@1.0.9: {}
 
   nopt@5.0.0:
@@ -36381,7 +37422,7 @@ snapshots:
 
   number-allocator@1.0.14:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       js-sdsl: 4.3.0
     transitivePeerDependencies:
       - supports-color
@@ -36624,6 +37665,14 @@ snapshots:
       - utf-8-validate
       - zod
 
+  opensea-js@7.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@opensea/seaport-js': 4.1.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   optimism@0.18.1:
     dependencies:
       '@wry/caches': 1.0.1
@@ -36666,8 +37715,8 @@ snapshots:
   ox@0.6.7(typescript@5.6.3)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.6.3)(zod@3.23.8)
@@ -36677,14 +37726,14 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.6.3)(zod@3.24.2):
+  ox@0.6.7(typescript@5.6.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.6.3)(zod@3.24.2)
+      abitype: 1.0.8(typescript@5.6.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.6.3
@@ -36694,8 +37743,8 @@ snapshots:
   ox@0.6.7(typescript@5.8.2)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.8.2)(zod@3.23.8)
@@ -36708,8 +37757,8 @@ snapshots:
   ox@0.6.7(typescript@5.8.2)(zod@3.24.1):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.8.2)(zod@3.24.1)
@@ -36719,14 +37768,14 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.8.2)(zod@3.24.2):
+  ox@0.6.7(typescript@5.8.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.8.2
+      '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.2)(zod@3.24.2)
+      abitype: 1.0.8(typescript@5.8.2)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.2
@@ -36764,6 +37813,13 @@ snapshots:
   p-cancelable@2.1.1: {}
 
   p-cancelable@3.0.0: {}
+
+  p-defer@3.0.0: {}
+
+  p-fifo@1.0.0:
+    dependencies:
+      fast-fifo: 1.3.2
+      p-defer: 3.0.0
 
   p-filter@2.1.0:
     dependencies:
@@ -36851,6 +37907,8 @@ snapshots:
       hash-base: 3.0.5
       pbkdf2: 3.1.2
       safe-buffer: 5.2.1
+
+  parse-duration@1.1.2: {}
 
   parse-headers@2.0.5: {}
 
@@ -36990,6 +38048,8 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  picomatch@4.0.4: {}
+
   pify@2.3.0: {}
 
   pify@3.0.0: {}
@@ -37064,6 +38124,8 @@ snapshots:
   pirates@4.0.6: {}
 
   pkce-challenge@4.1.0: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@3.0.0:
     dependencies:
@@ -37332,6 +38394,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  pstree.remy@1.1.8: {}
+
   public-encrypt@4.0.3:
     dependencies:
       bn.js: 4.12.2
@@ -37543,6 +38607,10 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-native-fetch-api@3.0.0:
+    dependencies:
+      p-defer: 3.0.0
+
   react-native-get-random-values@1.11.0(react-native@0.74.0(@babel/core@7.26.0)(@babel/preset-env@7.27.2(@babel/core@7.26.0))(@types/react@18.3.18)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)):
     dependencies:
       fast-base64-decode: 1.0.0
@@ -37696,6 +38764,12 @@ snapshots:
       source-map: 0.6.1
       tslib: 2.8.1
 
+  receptacle@1.3.2:
+    dependencies:
+      ms: 2.1.3
+
+  reconnecting-eventsource@1.6.5: {}
+
   redeyed@2.1.1:
     dependencies:
       esprima: 4.0.1
@@ -37826,7 +38900,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       module-details-from-path: 1.0.3
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -37868,6 +38942,8 @@ snapshots:
       signal-exit: 3.0.7
 
   ret@0.1.15: {}
+
+  retimer@3.0.0: {}
 
   retry-request@7.0.2(encoding@0.1.13):
     dependencies:
@@ -37925,7 +39001,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.25.4)(rollup@4.40.2):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       esbuild: 0.25.4
       get-tsconfig: 4.10.0
@@ -37991,7 +39067,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -38016,7 +39092,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
@@ -38056,6 +39132,20 @@ snapshots:
   scheduler@0.24.0-canary-efb381bbf-20230505:
     dependencies:
       loose-envify: 1.4.0
+
+  schema-to-yup@1.11.15:
+    dependencies:
+      dashify: 2.0.0
+      uniq: 1.0.1
+      uppercamelcase: 3.0.0
+      yup: 0.32.11
+
+  schema-to-yup@1.12.18:
+    dependencies:
+      dashify: 2.0.0
+      uniq: 1.0.1
+      uppercamelcase: 3.0.0
+      yup: 1.6.1
 
   scrypt-js@3.0.1: {}
 
@@ -38127,7 +39217,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -38360,6 +39450,10 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.7.1
 
   sisteransi@1.0.5: {}
 
@@ -38613,6 +39707,10 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
+  stream-to-it@0.2.4:
+    dependencies:
+      get-iterator: 1.0.2
+
   streamsearch@1.1.0: {}
 
   streamx@2.21.1:
@@ -38622,6 +39720,8 @@ snapshots:
       text-decoder: 1.2.3
     optionalDependencies:
       bare-events: 2.5.1
+
+  strict-event-emitter-types@2.0.0: {}
 
   strict-uri-encode@1.1.0: {}
 
@@ -38717,6 +39817,10 @@ snapshots:
   superstruct@1.0.4: {}
 
   superstruct@2.0.2: {}
+
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -38954,6 +40058,10 @@ snapshots:
 
   timed-out@4.0.1: {}
 
+  timeout-abort-controller@3.0.0:
+    dependencies:
+      retimer: 3.0.0
+
   tiny-case@1.0.3: {}
 
   tiny-inflate@1.0.3: {}
@@ -39046,6 +40154,8 @@ snapshots:
   toml@3.0.0: {}
 
   toposort@2.0.2: {}
+
+  touch@3.1.1: {}
 
   tough-cookie@2.5.0:
     dependencies:
@@ -39194,7 +40304,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -39222,7 +40332,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -39358,6 +40468,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undefsafe@2.0.5: {}
+
   underscore@1.13.7: {}
 
   undici-types@5.26.5: {}
@@ -39409,6 +40521,8 @@ snapshots:
       is-extendable: 0.1.1
       set-value: 2.0.1
 
+  uniq@1.0.1: {}
+
   unique-names-generator@4.7.1: {}
 
   unist-util-is@6.0.0:
@@ -39451,10 +40565,26 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-swc@1.5.9(@swc/core@1.10.1(@swc/helpers@0.5.17))(rollup@4.40.2):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.40.2)
+      '@swc/core': 1.10.1(@swc/helpers@0.5.17)
+      load-tsconfig: 0.2.5
+      unplugin: 2.3.11
+    transitivePeerDependencies:
+      - rollup
+
   unplugin-utils@0.2.4:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.2
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
 
   unset-value@1.0.0:
     dependencies:
@@ -39497,6 +40627,10 @@ snapshots:
   upper-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  uppercamelcase@3.0.0:
+    dependencies:
+      camelcase: 4.1.0
 
   uri-js@4.4.1:
     dependencies:
@@ -39612,6 +40746,8 @@ snapshots:
 
   varint@5.0.2: {}
 
+  varint@6.0.0: {}
+
   vary@1.1.2: {}
 
   verror@1.10.0:
@@ -39666,15 +40802,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.24.2):
+  viem@2.22.19(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.6.3)(zod@3.24.2)
+      abitype: 1.0.8(typescript@5.6.3)(zod@3.25.76)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.6.3)(zod@3.24.2)
+      ox: 0.6.7(typescript@5.6.3)(zod@3.25.76)
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.6.3
@@ -39751,15 +40887,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2):
+  viem@2.23.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.8.2)(zod@3.24.2)
+      abitype: 1.0.8(typescript@5.8.2)(zod@3.25.76)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.8.2)(zod@3.24.2)
+      ox: 0.6.7(typescript@5.8.2)(zod@3.25.76)
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.8.2
@@ -39805,7 +40941,7 @@ snapshots:
   vite-node@2.1.9(@types/node@18.19.69)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.11(@types/node@18.19.69)(terser@5.37.0)
@@ -39823,7 +40959,7 @@ snapshots:
   vite-node@2.1.9(@types/node@18.19.74)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.11(@types/node@18.19.74)(terser@5.37.0)
@@ -39841,7 +40977,7 @@ snapshots:
   vite-node@2.1.9(@types/node@20.17.11)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.11(@types/node@20.17.11)(terser@5.37.0)
@@ -39859,7 +40995,7 @@ snapshots:
   vite-node@2.1.9(@types/node@22.13.13)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.13.13)(terser@5.37.0)
@@ -39877,7 +41013,7 @@ snapshots:
   vite-node@2.1.9(@types/node@22.7.4)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.7.4)(terser@5.37.0)
@@ -39952,7 +41088,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.1.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -39987,7 +41123,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.1.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -40022,7 +41158,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.1.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -40057,7 +41193,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.1.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -40092,7 +41228,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.1.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@5.5.0)
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -40653,6 +41789,8 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
+  webpack-virtual-modules@0.6.2: {}
+
   websocket@1.0.35:
     dependencies:
       bufferutil: 4.0.9
@@ -40989,9 +42127,9 @@ snapshots:
     dependencies:
       zod: 3.23.8
 
-  zod-to-json-schema@3.23.5(zod@3.24.2):
+  zod-to-json-schema@3.23.5(zod@3.25.76):
     dependencies:
-      zod: 3.24.2
+      zod: 3.25.76
 
   zod-to-json-schema@3.24.1(zod@3.23.8):
     dependencies:
@@ -41004,6 +42142,10 @@ snapshots:
   zod-to-json-schema@3.24.1(zod@3.24.2):
     dependencies:
       zod: 3.24.2
+
+  zod-to-json-schema@3.24.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.24.5(zod@3.23.8):
     dependencies:
@@ -41021,6 +42163,8 @@ snapshots:
   zod@3.24.1: {}
 
   zod@3.24.2: {}
+
+  zod@3.25.76: {}
 
   zustand@5.0.0(@types/react@18.3.18)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
# Relates to:

No upstream issue. Plugin source-of-truth lives at
[bosonprotocol/agentic-commerce](https://github.com/bosonprotocol/agentic-commerce);
this PR brings it into goat-sdk under the `@goat-sdk` namespace.

# Background

[Boson Protocol](https://www.bosonprotocol.io/) is a trust-minimised commerce
protocol for redeemable NFT vouchers that settle physical and digital goods.
Its agentic-commerce surface is exposed over MCP — any MCP-aware agent can
discover, commit to, and redeem offers without bespoke contract wiring.

`@bosonprotocol/agentic-commerce` already implements the GOAT plugin contract
end-to-end (tools, parameters, chain support); this in-tree package is a thin
re-export shim so goat-sdk users get a discoverable `@goat-sdk/plugin-boson`
namespace.

## What does this PR do?

- New package \`typescript/packages/plugins/boson/\` (\`@goat-sdk/plugin-boson\`,
  \`0.1.0\`, MIT) — re-exports \`BosonProtocolPlugin\`, \`bosonProtocolPlugin\`, and
  \`BosonProtocolOptions\` from \`@bosonprotocol/agentic-commerce@^1.2.4\`.
- New runnable example \`typescript/examples/by-use-case/evm-boson-commit/\`
  driven by \`@goat-sdk/adapter-vercel-ai\` + \`@ai-sdk/anthropic\` (Claude Sonnet 4.6).
- 10 supported EVM chain ids:

  | Endpoint | URL | Chains |
  |----------|-----|--------|
  | Production | \`https://mcp.bosonprotocol.io/mcp\` | Ethereum (1), Optimism (10), Polygon (137), Arbitrum (42161), Base (8453) |
  | Staging | \`https://mcp-staging.bosonprotocol.io/mcp\` | Polygon Amoy (80002), Base Sepolia (84532), Sepolia (11155111), Optimism Sepolia (11155420), Arbitrum Sepolia (421614) |

- Permanent demo offer (\`offerId 358\` on \`staging-80002-0\`) created so
  reviewers can drive \`commit_to_offer\` end-to-end without listing their own
  goods. Documented in the example README.
- Adds a \`minor\` changeset for \`@goat-sdk/plugin-boson\`.
- Root [\`README.md\`](README.md): adds a Boson row to the plugin table.

# Testing

```bash
cd typescript
pnpm install
pnpm -F @goat-sdk/plugin-boson build       # tsup ESM + CJS + d.ts
pnpm -F @goat-sdk/plugin-boson test        # 14 vitest cases
pnpm biome check --diagnostic-level=error packages/plugins/boson examples/by-use-case/evm-boson-commit
```

End-to-end (≈30 s, Polygon Amoy):

```bash
cd typescript/examples/by-use-case/evm-boson-commit
cp example-config.md .env  # set WALLET_PRIVATE_KEY (Amoy-funded) + ANTHROPIC_API_KEY
pnpm install
pnpm tsx index.ts
> List the configIds, then commit to offer 358 on staging-80002-0 — it's the
  GOAT SDK permanent demo offer (1 wei, ~1B commits available). Don't redeem.
```

## Detailed testing results

Wallet used: \`0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8\` (Polygon Amoy testnet).

| Method | Prompt | Result | Transaction Link |
|--------|--------|--------|------------------|
| \`bosonProtocolPlugin()\` factory + \`supportsChain\` | 14 vitest cases — instantiation, name, tool providers count, support assertions for chain ids 1, 10, 137, 8453, 42161, 80002, 84532, 11155111, 11155420, 421614, plus rejection of BNB (56) and a Solana chain | All 14 pass | _N/A — unit tests_ |
| \`boson_get_config_ids\` (live MCP) | "Call boson_get_config_ids and report the raw configIds" against staging | \`["staging-80002-0","staging-84532-0","staging-11155111-0","staging-11155420-0","staging-421614-0"]\` | _read-only_ |
| \`boson_get_offers\` (live MCP) | \`configId=staging-80002-0, first=3\` | Returned offer ids \`1\`, \`10\`, \`100\` with prices and seller info | _read-only_ |
| \`boson_create_seller\` | "Register me as a seller via boson_create_seller … type=SELLER, kind=profile" | Seller id \`42\` | [\`0xa584d2…79406\`](https://amoy.polygonscan.com/tx/0xa584d2840f6331d39a346a35f09291e927d0bb4db2099cb094b0ed75de679406) |
| \`boson_create_offer\` | "Create offer … price=1, exchangeToken=native, validUntil=max, …" | Offer id \`358\` (price 1 wei, qty 999,999,999, voided=false) | [\`0xa4a423…7724e\`](https://amoy.polygonscan.com/tx/0xa4a4236d413c5ede559854a63e556b4e8ede0d071a69d9f1f91d0d8423f7724e) |
| \`boson_commit_to_offer\` | "Commit to offer 358 on staging-80002-0" | Exchange id \`644\`, state \`COMMITTED\`, voucher valid 1 year | [\`0xcd81dc…6980\`](https://amoy.polygonscan.com/tx/0xcd81dc5c2c2e7d05ed8a4c84e0263f79fc16fc437cc2a65ce5e3028eecf46980) |

# Docs

My changes do not require a change to the project documentation site; the
in-tree [\`packages/plugins/boson/README.md\`](typescript/packages/plugins/boson/README.md)
covers configuration, the endpoint matrix, the full tool reference, and
compatibility. The root [\`README.md\`](README.md) plugin table has been updated.

## Checklist
- [x] I have tested this change. Unit tests pass; live transactions for
      \`create_seller\`, \`create_offer\`, and \`commit_to_offer\` are linked above.
- [x] I updated the [README](README.md) (root plugin table + example README).

If you require releasing a new version of the package:
- [x] I have added a changeset (\`typescript/.changeset/add-plugin-boson.md\`,
      \`minor\` for \`@goat-sdk/plugin-boson\`).